### PR TITLE
Use `bash' instead of `sh' for classification-results.sh.

### DIFF
--- a/classification-results.sh
+++ b/classification-results.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016-present, Facebook, Inc.
 # All rights reserved.


### PR DESCRIPTION
Use `bash` instead of `sh` for classification-results.sh.

Fixes issue #1.