### PR TITLE
Prevent 'double free' runtime error on utils

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -10,12 +10,14 @@
 #include "utils.h"
 #include <cmath>
 #include <ios>
+#include <assert.h>
 
 namespace utils {
   real* t_sigmoid;
   real* t_log;
 
   real log(real x) {
+    assert(t_log != NULL);
     if (x > 1.0) {
       return 0.0;
     }
@@ -24,6 +26,7 @@ namespace utils {
   }
 
   real sigmoid(real x) {
+    assert(t_sigmoid != NULL);
     if (x < -MAX_SIGMOID) {
       return 0.0;
     } else if (x > MAX_SIGMOID) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -58,6 +58,8 @@ namespace utils {
   void freeTables() {
     delete[] t_sigmoid;
     delete[] t_log;
+    t_sigmoid = NULL;
+    t_log = NULL;
   }
 
   int64_t size(std::ifstream& ifs) {


### PR DESCRIPTION
Currently if `utils::freeTables()` called twice, it cause a `double free` runtime error (or undefined behaviour if program is not crashed). 

I found this bug when creating the Python interface for fastText:

```
(fasttext) % python
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import fasttext.utils as u
>>> u.init_tables()
>>> u.log(0.1)
-2.3064987659454346
>>> u.sigmoid(0.2212)
0.5544704794883728
>>> u.free_tables()
>>> u.free_tables()
*** Error in `python': double free or corruption (!prev): 0x0000000000ce1e90 ***
Aborted (core dumped)
```

This patch prevent `double free` runtime error and add `NULL` checking to `utils` module.
