### PR TITLE
Add bound checking to Dictionary::getLabel(lid)

### DIFF
--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -258,6 +258,7 @@ int32_t Dictionary::getLine(std::ifstream& ifs,
 }
 
 std::string Dictionary::getLabel(int32_t lid) {
+  assert(lid >= 0 && lid < nlabels_);
   return words_[lid + nwords_].word;
 }
 


### PR DESCRIPTION
This patch add bound checking to `Dictionary::getLabel(lid)`