### PR TITLE
Make sure the right sizes are always being passed to ifs.read and ofs.write

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -141,36 +141,36 @@ void Args::printHelp() {
 
 void Args::save(std::ofstream& ofs) {
   if (ofs.is_open()) {
-    ofs.write((char*) &(dim), sizeof(int));
-    ofs.write((char*) &(ws), sizeof(int));
-    ofs.write((char*) &(epoch), sizeof(int));
-    ofs.write((char*) &(minCount), sizeof(int));
-    ofs.write((char*) &(neg), sizeof(int));
-    ofs.write((char*) &(wordNgrams), sizeof(int));
-    ofs.write((char*) &(loss), sizeof(loss_name));
-    ofs.write((char*) &(model), sizeof(model_name));
-    ofs.write((char*) &(bucket), sizeof(int));
-    ofs.write((char*) &(minn), sizeof(int));
-    ofs.write((char*) &(maxn), sizeof(int));
-    ofs.write((char*) &(lrUpdateRate), sizeof(int));
-    ofs.write((char*) &(t), sizeof(double));
+    ofs.write((char*) &(dim), sizeof(dim));
+    ofs.write((char*) &(ws), sizeof(ws));
+    ofs.write((char*) &(epoch), sizeof(epoch));
+    ofs.write((char*) &(minCount), sizeof(minCount));
+    ofs.write((char*) &(neg), sizeof(neg));
+    ofs.write((char*) &(wordNgrams), sizeof(wordNgrams));
+    ofs.write((char*) &(loss), sizeof(loss));
+    ofs.write((char*) &(model), sizeof(model));
+    ofs.write((char*) &(bucket), sizeof(bucket));
+    ofs.write((char*) &(minn), sizeof(minn));
+    ofs.write((char*) &(maxn), sizeof(maxn));
+    ofs.write((char*) &(lrUpdateRate), sizeof(lrUpdateRate));
+    ofs.write((char*) &(t), sizeof(t));
   }
 }
 
 void Args::load(std::ifstream& ifs) {
   if (ifs.is_open()) {
-    ifs.read((char*) &(dim), sizeof(int));
-    ifs.read((char*) &(ws), sizeof(int));
-    ifs.read((char*) &(epoch), sizeof(int));
-    ifs.read((char*) &(minCount), sizeof(int));
-    ifs.read((char*) &(neg), sizeof(int));
-    ifs.read((char*) &(wordNgrams), sizeof(int));
-    ifs.read((char*) &(loss), sizeof(loss_name));
-    ifs.read((char*) &(model), sizeof(model_name));
-    ifs.read((char*) &(bucket), sizeof(int));
-    ifs.read((char*) &(minn), sizeof(int));
-    ifs.read((char*) &(maxn), sizeof(int));
-    ifs.read((char*) &(lrUpdateRate), sizeof(int));
-    ifs.read((char*) &(t), sizeof(double));
+    ifs.read((char*) &(dim), sizeof(dim));
+    ifs.read((char*) &(ws), sizeof(ws));
+    ifs.read((char*) &(epoch), sizeof(epoch));
+    ifs.read((char*) &(minCount), sizeof(minCount));
+    ifs.read((char*) &(neg), sizeof(neg));
+    ifs.read((char*) &(wordNgrams), sizeof(wordNgrams));
+    ifs.read((char*) &(loss), sizeof(loss));
+    ifs.read((char*) &(model), sizeof(model));
+    ifs.read((char*) &(bucket), sizeof(bucket));
+    ifs.read((char*) &(minn), sizeof(minn));
+    ifs.read((char*) &(maxn), sizeof(maxn));
+    ifs.read((char*) &(lrUpdateRate), sizeof(lrUpdateRate));
+    ifs.read((char*) &(t), sizeof(t));
   }
 }

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -272,16 +272,16 @@ std::string Dictionary::getLabel(int32_t lid) {
 }
 
 void Dictionary::save(std::ofstream& ofs) {
-  ofs.write((char*) &size_, sizeof(int32_t));
-  ofs.write((char*) &nwords_, sizeof(int32_t));
-  ofs.write((char*) &nlabels_, sizeof(int32_t));
-  ofs.write((char*) &ntokens_, sizeof(int64_t));
+  ofs.write((char*) &size_, sizeof(size_));
+  ofs.write((char*) &nwords_, sizeof(nwords_));
+  ofs.write((char*) &nlabels_, sizeof(nlabels_));
+  ofs.write((char*) &ntokens_, sizeof(ntokens_));
   for (int32_t i = 0; i < size_; i++) {
     entry e = words_[i];
     ofs.write(e.word.data(), e.word.size() * sizeof(char));
     ofs.put(0);
-    ofs.write((char*) &(e.count), sizeof(int64_t));
-    ofs.write((char*) &(e.type), sizeof(entry_type));
+    ofs.write((char*) &(e.count), sizeof(e.count));
+    ofs.write((char*) &(e.type), sizeof(e.type));
   }
 }
 
@@ -290,18 +290,18 @@ void Dictionary::load(std::ifstream& ifs) {
   for (int32_t i = 0; i < MAX_VOCAB_SIZE; i++) {
     word2int_[i] = -1;
   }
-  ifs.read((char*) &size_, sizeof(int32_t));
-  ifs.read((char*) &nwords_, sizeof(int32_t));
-  ifs.read((char*) &nlabels_, sizeof(int32_t));
-  ifs.read((char*) &ntokens_, sizeof(int64_t));
+  ifs.read((char*) &size_, sizeof(size_));
+  ifs.read((char*) &nwords_, sizeof(nwords_));
+  ifs.read((char*) &nlabels_, sizeof(nlabels_));
+  ifs.read((char*) &ntokens_, sizeof(ntokens_));
   for (int32_t i = 0; i < size_; i++) {
     char c;
     entry e;
     while ((c = ifs.get()) != 0) {
       e.word.push_back(c);
     }
-    ifs.read((char*) &e.count, sizeof(int64_t));
-    ifs.read((char*) &e.type, sizeof(entry_type));
+    ifs.read((char*) &e.count, sizeof(e.count));
+    ifs.read((char*) &e.type, sizeof(e.type));
     words_.push_back(e);
     word2int_[find(e.word)] = i;
   }

--- a/src/matrix.cc
+++ b/src/matrix.cc
@@ -84,14 +84,14 @@ real Matrix::dotRow(const Vector& vec, int64_t i) {
 }
 
 void Matrix::save(std::ofstream& ofs) {
-  ofs.write((char*) &m_, sizeof(int64_t));
-  ofs.write((char*) &n_, sizeof(int64_t));
+  ofs.write((char*) &m_, sizeof(m_));
+  ofs.write((char*) &n_, sizeof(n_));
   ofs.write((char*) data_, m_ * n_ * sizeof(real));
 }
 
 void Matrix::load(std::ifstream& ifs) {
-  ifs.read((char*) &m_, sizeof(int64_t));
-  ifs.read((char*) &n_, sizeof(int64_t));
+  ifs.read((char*) &m_, sizeof(m_));
+  ifs.read((char*) &n_, sizeof(n_));
   delete[] data_;
   data_ = new real[m_ * n_];
   ifs.read((char*) data_, m_ * n_ * sizeof(real));


### PR DESCRIPTION
This patch change

```cpp
ofs.write((char*) &(var), sizeof(var_type));
ifs.read((char*) &(var), sizeof(var_type));
```
to

```cpp
ofs.write((char*) &(var), sizeof(var));
ifs.read((char*) &(var), sizeof(var));
```
For make sure that the right sizes are __always__ being passed to `ifs.read` and `ofs.write`