### PR TITLE
Update README: `model.vec` not generated for classifier model

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ ./fasttext supervised -input train.txt -output model
 
 where `train.txt` is a text file containing a training sentence per line along with the labels.
 By default, we assume that labels are words that are prefixed by the string `__label__`.
-This will output two files: `model.bin` and `model.vec`.
+This will output one file: `model.bin`.
 Once the model was trained, you can evaluate it by computing the precision and recall at k (P@k and R@k) on a test set using:
 
 ```


### PR DESCRIPTION
As https://github.com/facebookresearch/fastText/commit/32235263e10e0e76d6f62365a3c77586451f1aee, `model.vec` is not generated anymore for classifier model.