### PR TITLE
Speed up file reading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CXXFLAGS = -pthread -std=c++0x
 OBJS = args.o dictionary.o matrix.o vector.o model.o utils.o buffered.o
 INCLUDES = -I.
 
-opt: CXXFLAGS += -O3 -funroll-loops
+opt: CXXFLAGS += -O3 -funroll-loops -flto
 opt: fasttext
 
 debug: CXXFLAGS += -g -O0 -fno-inline

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 CXX = c++
 CXXFLAGS = -pthread -std=c++0x
-OBJS = args.o dictionary.o matrix.o vector.o model.o utils.o
+OBJS = args.o dictionary.o matrix.o vector.o model.o utils.o buffered.o
 INCLUDES = -I.
 
 opt: CXXFLAGS += -O3 -funroll-loops
@@ -21,7 +21,7 @@ debug: fasttext
 args.o: src/args.cc src/args.h
 	$(CXX) $(CXXFLAGS) -c src/args.cc
 
-dictionary.o: src/dictionary.cc src/dictionary.h src/args.h
+dictionary.o: src/dictionary.cc src/dictionary.h src/args.h src/buffered.h
 	$(CXX) $(CXXFLAGS) -c src/dictionary.cc
 
 matrix.o: src/matrix.cc src/matrix.h src/utils.h
@@ -30,11 +30,14 @@ matrix.o: src/matrix.cc src/matrix.h src/utils.h
 vector.o: src/vector.cc src/vector.h src/utils.h
 	$(CXX) $(CXXFLAGS) -c src/vector.cc
 
-model.o: src/model.cc src/model.h src/args.h
+model.o: src/model.cc src/model.h src/args.h src/matrix.h
 	$(CXX) $(CXXFLAGS) -c src/model.cc
 
 utils.o: src/utils.cc src/utils.h
 	$(CXX) $(CXXFLAGS) -c src/utils.cc
+
+buffered.o: src/buffered.cc src/buffered.h
+	$(CXX) $(CXXFLAGS) -c src/buffered.cc
 
 fasttext : $(OBJS) src/fasttext.cc
 	$(CXX) $(CXXFLAGS) $(OBJS) src/fasttext.cc -o fasttext

--- a/src/buffered.cc
+++ b/src/buffered.cc
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "buffered.h"
+
+void Buffered::fetch() {
+  cursor_ = 0;
+  is_->read(buf_.data(), BUF_SIZE);
+  buf_last_ = is_->gcount() - 1;
+}
+
+Buffered::Buffered(std::unique_ptr<std::istream>&& is)
+  : is_(std::move(is))
+{
+  fetch();
+}
+
+bool Buffered::eof() const {
+  return cursor_ >= buf_last_ && is_->eof();
+}
+
+bool Buffered::peek(char& c) const {
+  if (eof())
+    return false;
+  c = buf_[cursor_];
+  return true;
+}
+
+void Buffered::advance() {
+  if (cursor_ < buf_last_)
+    cursor_++;
+  else if (!is_->eof())
+    fetch();
+}
+
+void Buffered::reset() {
+  is_->clear();
+  is_->seekg(0);
+  fetch();
+}

--- a/src/buffered.h
+++ b/src/buffered.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef FASTTEXT_BUFFERED_H
+#define FASTTEXT_BUFFERED_H
+
+#include <array>
+#include <fstream>
+#include <memory>
+
+// istream wrapper for efficient char by char reading
+class Buffered {
+  private:
+    static const int32_t BUF_SIZE = 512;
+
+    std::array<char, BUF_SIZE> buf_;
+    std::unique_ptr<std::istream> is_;
+    int32_t cursor_;
+    int32_t buf_last_;
+
+    void fetch();
+
+  public:
+    Buffered(std::unique_ptr<std::istream>&&);
+
+    bool eof() const;
+
+    // if stream at eof, leave `c` unchanged and return false
+    // otherwise, assign the current character to `c` and return true
+    bool peek(char& c) const;
+
+    // seek one character forward
+    void advance();
+
+    // clear flags and seek to the beginning
+    void reset();
+};
+
+#endif

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -19,6 +19,7 @@
 
 #include "args.h"
 #include "real.h"
+#include "buffered.h"
 
 typedef int32_t id_type;
 enum class entry_type : int8_t {word=0, label=1};
@@ -67,14 +68,14 @@ class Dictionary {
     void computeNgrams(const std::string&, std::vector<int32_t>&);
     uint32_t hash(const std::string& str);
     void add(const std::string&);
-    bool readWord(std::istream&, std::string&);
-    void readFromFile(std::istream&);
+    bool readWord(Buffered&, std::string&);
+    void readFromFile(Buffered&);
     std::string getLabel(int32_t);
     void save(std::ostream&);
     void load(std::istream&);
     std::vector<int64_t> getCounts(entry_type);
     void addNgrams(std::vector<int32_t>&, int32_t);
-    int32_t getLine(std::istream&, std::vector<int32_t>&,
+    int32_t getLine(Buffered&, std::vector<int32_t>&,
                     std::vector<int32_t>&, std::minstd_rand&);
 };
 


### PR DESCRIPTION
Hi!

This PR improves performance by using a more efficient abstraction on top of istream. Link-time optimization is needed to inline `eof`, `peek`, and `advance`. Alternatively these functions could be moved to the header file. I got the following speedup on my machine:
- `classification-example.sh`: 20.3s -> 12.8s
- `classification-results.sh`: 9m -> 5m14s
- `word-vector-example.sh`: 4m31s -> 4m4s