### PR TITLE
Read directly from the stream buffer

### DIFF
--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -147,10 +147,10 @@ void Dictionary::initNgrams() {
 bool Dictionary::readWord(std::istream& in, std::string& word)
 {
   char c;
+  std::streambuf& sb = *in.rdbuf();
   word.clear();
-  while (in.peek() != EOF) {
-    in.get(c);
-    if (isspace(c) || c == 0) {
+  while ((c = sb.sbumpc()) != EOF) {
+    if (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '\v' || c == '\f' || c == '\0') {
       if (word.empty()) {
         if (c == '\n') {
           word += EOS;
@@ -158,12 +158,15 @@ bool Dictionary::readWord(std::istream& in, std::string& word)
         }
         continue;
       } else {
-        if (c == '\n') in.unget();
+        if (c == '\n')
+          sb.sungetc();
         return true;
       }
     }
     word.push_back(c);
   }
+  // trigger eofbit
+  in.get();
   return !word.empty();
 }
 


### PR DESCRIPTION
This PR improves performance by using `streambuf::sbumpc` and `streambuf::sungetc` instead of `istream` functions. I got the following speedup on my machine:
- `classification-example.sh`: 20.1s -> 13.6s
- `classification-results.sh`: 8m58s -> 5m49s
- `word-vector-example.sh`: 4m39s -> 4m24s

LTO may be worth enabling, as it shaves off another 2% or so of runtime.