### PR TITLE
Add support for reading test data from stdin

### DIFF
--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -44,8 +44,8 @@ class FastText {
                     const std::vector<int32_t>&);
     void cbow(Model&, real, const std::vector<int32_t>&);
     void skipgram(Model&, real, const std::vector<int32_t>&);
-    void test(const std::string&, int32_t);
-    void predict(const std::string&, int32_t, bool);
+    void test(std::istream&, int32_t);
+    void predict(std::istream&, int32_t, bool);
     void wordVectors();
     void textVectors();
     void printVectors();


### PR DESCRIPTION
For "predict" and "test" operation, an input filename of "-" now
causes the test data to be read from stdin. This allows other
processes to easily pipe data into fastTest.
It'd be nice if this could be supported for training too, but
the training code needs to be able to seek about in the data,
which really requires a proper file.