### PR TITLE
Refactor to make fastText easier to use as a C++ library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ utils.o: src/utils.cc src/utils.h
 fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc
 
-fasttext: $(OBJS) src/fasttext.cc
+fasttext: $(OBJS) src/main.cc
 	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext
 
 clean:

--- a/src/args.cc
+++ b/src/args.cc
@@ -24,8 +24,8 @@ Args::Args() {
   minCount = 5;
   neg = 5;
   wordNgrams = 1;
-  loss = loss_name::ns;
-  model = model_name::sg;
+  loss = loss_type::ns;
+  model = model_type::sg;
   bucket = 2000000;
   minn = 3;
   maxn = 6;
@@ -40,14 +40,14 @@ Args::Args() {
 void Args::parseArgs(int argc, char** argv) {
   std::string command(argv[1]);
   if (command == "supervised") {
-    model = model_name::sup;
-    loss = loss_name::softmax;
+    model = model_type::sup;
+    loss = loss_type::softmax;
     minCount = 1;
     minn = 0;
     maxn = 0;
     lr = 0.1;
   } else if (command == "cbow") {
-    model = model_name::cbow;
+    model = model_type::cbow;
   }
   int ai = 2;
   while (ai < argc) {
@@ -84,11 +84,11 @@ void Args::parseArgs(int argc, char** argv) {
       wordNgrams = atoi(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-loss") == 0) {
       if (strcmp(argv[ai + 1], "hs") == 0) {
-        loss = loss_name::hs;
+        loss = loss_type::hs;
       } else if (strcmp(argv[ai + 1], "ns") == 0) {
-        loss = loss_name::ns;
+        loss = loss_type::ns;
       } else if (strcmp(argv[ai + 1], "softmax") == 0) {
-        loss = loss_name::softmax;
+        loss = loss_type::softmax;
       } else {
         std::cout << "Unknown loss: " << argv[ai + 1] << std::endl;
         printHelp();
@@ -129,8 +129,8 @@ void Args::parseArgs(int argc, char** argv) {
 
 void Args::printHelp() {
   std::string lname = "ns";
-  if (loss == loss_name::hs) lname = "hs";
-  if (loss == loss_name::softmax) lname = "softmax";
+  if (loss == loss_type::hs) lname = "hs";
+  if (loss == loss_type::softmax) lname = "softmax";
   std::cout
     << "\n"
     << "The following arguments are mandatory:\n"
@@ -164,8 +164,8 @@ void Args::save(std::ostream& out) {
   out.write((char*) &(minCount), sizeof(int));
   out.write((char*) &(neg), sizeof(int));
   out.write((char*) &(wordNgrams), sizeof(int));
-  out.write((char*) &(loss), sizeof(loss_name));
-  out.write((char*) &(model), sizeof(model_name));
+  out.write((char*) &(loss), sizeof(loss_type));
+  out.write((char*) &(model), sizeof(model_type));
   out.write((char*) &(bucket), sizeof(int));
   out.write((char*) &(minn), sizeof(int));
   out.write((char*) &(maxn), sizeof(int));
@@ -180,8 +180,8 @@ void Args::load(std::istream& in) {
   in.read((char*) &(minCount), sizeof(int));
   in.read((char*) &(neg), sizeof(int));
   in.read((char*) &(wordNgrams), sizeof(int));
-  in.read((char*) &(loss), sizeof(loss_name));
-  in.read((char*) &(model), sizeof(model_name));
+  in.read((char*) &(loss), sizeof(loss_type));
+  in.read((char*) &(model), sizeof(model_type));
   in.read((char*) &(bucket), sizeof(int));
   in.read((char*) &(minn), sizeof(int));
   in.read((char*) &(maxn), sizeof(int));

--- a/src/args.h
+++ b/src/args.h
@@ -16,8 +16,8 @@
 
 namespace fasttext {
 
-enum class model_name : int {cbow=1, sg, sup};
-enum class loss_name : int {hs=1, ns, softmax};
+enum class model_type : int {cbow=1, sg, sup};
+enum class loss_type : int {hs=1, ns, softmax};
 
 class Args {
   public:
@@ -33,8 +33,8 @@ class Args {
     int minCount;
     int neg;
     int wordNgrams;
-    loss_name loss;
-    model_name model;
+    loss_type loss;
+    model_type model;
     int bucket;
     int minn;
     int maxn;

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -89,7 +89,7 @@ const std::vector<int32_t> Dictionary::getNgrams(const std::string& word) const 
 bool Dictionary::discard(int32_t id, real rand) const {
   assert(id >= 0);
   assert(id < nwords_);
-  if (args_->model == model_name::sup) return false;
+  if (args_->model == model_type::sup) return false;
   return rand > pdiscard_[id];
 }
 
@@ -272,7 +272,7 @@ int32_t Dictionary::getLine(std::istream& in,
     if (type == entry_type::label) {
       labels.push_back(wid - nwords_);
     }
-    if (words.size() > MAX_LINE_SIZE && args_->model != model_name::sup) break;
+    if (words.size() > MAX_LINE_SIZE && args_->model != model_type::sup) break;
   }
   return ntokens;
 }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -229,6 +229,13 @@ bool FastText::getTextVectorNextLine(Vector &vec, std::istream &in) const {
   return true;
 }
 
+void FastText::getTextVector(Vector &vec, std::string text) const
+{
+  std::replace(text.begin(), text.end(), '\n', ' ');
+  std::istringstream in (text);
+  getTextVectorNextLine(vec, in);
+}
+
 void FastText::trainThread(int32_t threadId) {
   std::ifstream ifs(args_->input);
   utils::seek(ifs, threadId * utils::size(ifs) / args_->thread);

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -82,7 +82,7 @@ void FastText::loadModel(std::istream& in) {
   input_->load(in);
   output_->load(in);
   model_ = std::make_shared<Model>(input_, output_, args_, 0);
-  if (args_->model == model_name::sup) {
+  if (args_->model == model_type::sup) {
     model_->setTargetCounts(dict_->getCounts(entry_type::label));
   } else {
     model_->setTargetCounts(dict_->getCounts(entry_type::word));
@@ -228,7 +228,7 @@ void FastText::textVectors() {
 }
 
 void FastText::printVectors() {
-  if (args_->model == model_name::sup) {
+  if (args_->model == model_type::sup) {
     textVectors();
   } else {
     wordVectors();
@@ -240,7 +240,7 @@ void FastText::trainThread(int32_t threadId) {
   utils::seek(ifs, threadId * utils::size(ifs) / args_->thread);
 
   Model model(input_, output_, args_, threadId);
-  if (args_->model == model_name::sup) {
+  if (args_->model == model_type::sup) {
     model.setTargetCounts(dict_->getCounts(entry_type::label));
   } else {
     model.setTargetCounts(dict_->getCounts(entry_type::word));
@@ -253,12 +253,12 @@ void FastText::trainThread(int32_t threadId) {
     real progress = real(tokenCount) / (args_->epoch * ntokens);
     real lr = args_->lr * (1.0 - progress);
     localTokenCount += dict_->getLine(ifs, line, labels, model.rng);
-    if (args_->model == model_name::sup) {
+    if (args_->model == model_type::sup) {
       dict_->addNgrams(line, args_->wordNgrams);
       supervised(model, lr, line, labels);
-    } else if (args_->model == model_name::cbow) {
+    } else if (args_->model == model_type::cbow) {
       cbow(model, lr, line);
-    } else if (args_->model == model_name::sg) {
+    } else if (args_->model == model_type::sg) {
       skipgram(model, lr, line);
     }
     if (localTokenCount > args_->lrUpdateRate) {
@@ -339,7 +339,7 @@ void FastText::train(std::shared_ptr<Args> args) {
     input_->uniform(1.0 / args_->dim);
   }
 
-  if (args_->model == model_name::sup) {
+  if (args_->model == model_type::sup) {
     output_ = std::make_shared<Matrix>(dict_->nlabels(), args_->dim);
   } else {
     output_ = std::make_shared<Matrix>(dict_->nwords(), args_->dim);
@@ -358,7 +358,7 @@ void FastText::train(std::shared_ptr<Args> args) {
   model_ = std::make_shared<Model>(input_, output_, args_, 0);
 
   saveModel();
-  if (args_->model != model_name::sup) {
+  if (args_->model != model_type::sup) {
     saveWordVectors();
   }
 }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -222,13 +222,7 @@ void FastText::textVectors() {
   while (std::cin.peek() != EOF) {
     dict_->getLine(std::cin, line, labels, model_->rng);
     dict_->addNgrams(line, args_->wordNgrams);
-    vec.zero();
-    for (auto it = line.cbegin(); it != line.cend(); ++it) {
-      vec.addRow(*input_, *it);
-    }
-    if (!line.empty()) {
-      vec.mul(1.0 / line.size());
-    }
+    model_->computeHidden(line, vec);
     std::cout << vec << std::endl;
   }
 }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <sstream>
 
 namespace fasttext {
 
@@ -194,6 +195,16 @@ bool FastText::predictNextLine(
     }
   }
   return true;
+}
+
+void FastText::predict(
+  std::string text,
+  int32_t k,
+  std::vector<std::pair<real, std::string>>& predictions
+) const {
+  std::replace(text.begin(), text.end(), '\n', ' ');
+  std::istringstream in (text);
+  predictNextLine(in, k, predictions);
 }
 
 void FastText::wordVectors() {

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -33,7 +33,7 @@ void FastText::getWordVector(Vector& vec, const std::string& word) {
   }
 }
 
-void FastText::saveVectors() {
+void FastText::saveWordVectors() {
   std::ofstream ofs(args_->output + ".vec");
   if (!ofs.is_open()) {
     std::cout << "Error opening file for saving vectors." << std::endl;
@@ -359,7 +359,7 @@ void FastText::train(std::shared_ptr<Args> args) {
 
   saveModel();
   if (args_->model != model_name::sup) {
-    saveVectors();
+    saveWordVectors();
   }
 }
 

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -19,6 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include <sstream>
+#include <stdexcept>
 
 namespace fasttext {
 model_type FastText::modelType() const {
@@ -26,6 +27,11 @@ model_type FastText::modelType() const {
 }
 
 void FastText::getWordVector(Vector& vec, const std::string& word) const {
+  if (modelType() == model_type::sup) {
+    throw std::runtime_error(
+      "Getting word vector from supervised model not supported");
+  }
+
   const std::vector<int32_t>& ngrams = dict_->getNgrams(word);
   if (vec.size() != args_->dim) {
     vec = Vector(args_->dim);
@@ -183,6 +189,11 @@ bool FastText::predictNextLine(
   int32_t k,
   std::vector<std::pair<real, std::string>> &predictions
 ) const {
+  if (modelType() != model_type::sup) {
+    throw std::runtime_error(
+      "Getting prediction from unsupervised model not supported");
+  }
+
   if (in.peek(), in.eof()) {
     return false;
   }
@@ -215,6 +226,11 @@ void FastText::predict(
 }
 
 bool FastText::getTextVectorNextLine(Vector &vec, std::istream &in) const {
+  if (modelType() == model_type::sup) {
+    throw std::runtime_error(
+      "Getting text vector from unsupervised model not supported");
+  }
+
   if (in.peek(), in.eof()) {
     return false;
   }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -22,7 +22,7 @@
 
 namespace fasttext {
 
-void FastText::getWordVector(Vector& vec, const std::string& word) {
+void FastText::getWordVector(Vector& vec, const std::string& word) const {
   const std::vector<int32_t>& ngrams = dict_->getNgrams(word);
   vec.zero();
   for (auto it = ngrams.begin(); it != ngrams.end(); ++it) {

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -22,7 +22,7 @@
 
 namespace fasttext {
 
-void FastText::getVector(Vector& vec, const std::string& word) {
+void FastText::getWordVector(Vector& vec, const std::string& word) {
   const std::vector<int32_t>& ngrams = dict_->getNgrams(word);
   vec.zero();
   for (auto it = ngrams.begin(); it != ngrams.end(); ++it) {
@@ -43,7 +43,7 @@ void FastText::saveVectors() {
   Vector vec(args_->dim);
   for (int32_t i = 0; i < dict_->nwords(); i++) {
     std::string word = dict_->getWord(i);
-    getVector(vec, word);
+    getWordVector(vec, word);
     ofs << word << " " << vec << std::endl;
   }
   ofs.close();
@@ -211,7 +211,7 @@ void FastText::wordVectors() {
   std::string word;
   Vector vec(args_->dim);
   while (std::cin >> word) {
-    getVector(vec, word);
+    getWordVector(vec, word);
     std::cout << word << " " << vec << std::endl;
   }
 }

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -60,6 +60,7 @@ class FastText {
       std::vector<std::pair<real, std::string>>&
     ) const;
     bool getTextVectorNextLine(Vector&, std::istream&) const;
+    void getTextVector(Vector&, std::string) const;
     void trainThread(int32_t);
     void train(std::shared_ptr<Args>);
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -36,6 +36,7 @@ class FastText {
     clock_t start;
 
   public:
+    model_type modelType() const;
     void getWordVector(Vector&, const std::string&) const;
     void saveWordVectors();
     void saveModel();
@@ -58,9 +59,7 @@ class FastText {
       int32_t,
       std::vector<std::pair<real, std::string>>&
     ) const;
-    void wordVectors();
-    void textVectors();
-    void printVectors();
+    bool getTextVectorNextLine(Vector&, std::istream&) const;
     void trainThread(int32_t);
     void train(std::shared_ptr<Args>);
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -53,6 +53,11 @@ class FastText {
       int32_t,
       std::vector<std::pair<real, std::string>>&
     ) const;
+    void predict(
+      std::string,
+      int32_t,
+      std::vector<std::pair<real, std::string>>&
+    ) const;
     void wordVectors();
     void textVectors();
     void printVectors();

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -37,7 +37,7 @@ class FastText {
 
   public:
     void getWordVector(Vector&, const std::string&);
-    void saveVectors();
+    void saveWordVectors();
     void saveModel();
     void loadModel(const std::string&);
     void loadModel(std::istream&);

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -36,7 +36,7 @@ class FastText {
     clock_t start;
 
   public:
-    void getVector(Vector&, const std::string&);
+    void getWordVector(Vector&, const std::string&);
     void saveVectors();
     void saveModel();
     void loadModel(const std::string&);

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -48,8 +48,11 @@ class FastText {
     void cbow(Model&, real, const std::vector<int32_t>&);
     void skipgram(Model&, real, const std::vector<int32_t>&);
     void test(std::istream&, int32_t);
-    void predict(std::istream&, int32_t, bool);
-    void predict(std::istream&, int32_t, std::vector<std::pair<real,std::string>>&) const;
+    bool predictNextLine(
+      std::istream&,
+      int32_t,
+      std::vector<std::pair<real, std::string>>&
+    ) const;
     void wordVectors();
     void textVectors();
     void printVectors();

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -36,7 +36,7 @@ class FastText {
     clock_t start;
 
   public:
-    void getWordVector(Vector&, const std::string&);
+    void getWordVector(Vector&, const std::string&) const;
     void saveWordVectors();
     void saveModel();
     void loadModel(const std::string&);

--- a/src/main.cc
+++ b/src/main.cc
@@ -91,23 +91,39 @@ void predict(int argc, char** argv) {
     exit(EXIT_FAILURE);
   }
   bool print_prob = std::string(argv[1]) == "predict-prob";
+
   FastText fasttext;
   fasttext.loadModel(std::string(argv[2]));
 
+  std::ifstream ifs;
   std::string infile(argv[3]);
-  if (infile == "-") {
-    fasttext.predict(std::cin, k, print_prob);
-  } else {
-    std::ifstream ifs(infile);
+  if (infile != "-") {
+    ifs.open(infile);
     if (!ifs.is_open()) {
       std::cerr << "Input file cannot be opened!" << std::endl;
       exit(EXIT_FAILURE);
     }
-    fasttext.predict(ifs, k, print_prob);
-    ifs.close();
   }
 
-  exit(0);
+  std::istream &in = infile != "-" ? ifs : std::cin;
+  std::vector<std::pair<real, std::string>> predictions;
+  while (fasttext.predictNextLine(in, k, predictions)) {
+    if (predictions.empty()) {
+      std::cout << "n/a" << std::endl;
+      continue;
+    }
+
+    for (auto it = predictions.cbegin(); it != predictions.cend(); it++) {
+      if (it != predictions.cbegin()) {
+        std::cout << ' ';
+      }
+      std::cout << it->second;
+      if (print_prob) {
+        std::cout << ' ' << exp(it->first);
+      }
+    }
+    std::cout << std::endl;
+  }
 }
 
 void printVectors(int argc, char** argv) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -133,8 +133,18 @@ void printVectors(int argc, char** argv) {
   }
   FastText fasttext;
   fasttext.loadModel(std::string(argv[2]));
-  fasttext.printVectors();
-  exit(0);
+  Vector vec;
+  if (fasttext.modelType() == model_type::sup) {
+    while (fasttext.getTextVectorNextLine(vec, std::cin)) {
+      std::cout << vec << std::endl;
+    }
+  } else {
+    std::string word;
+    while (std::cin >> word) {
+      fasttext.getWordVector(vec, word);
+      std::cout << word << " " << vec << std::endl;
+    }
+  }
 }
 
 void train(int argc, char** argv) {

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <istream>
 #include <ostream>
+#include <memory>
 
 #include "real.h"
 
@@ -23,15 +24,16 @@ class Vector;
 class Matrix {
 
   public:
-    real* data_;
+    std::unique_ptr<real[]> data_;
     int64_t m_;
     int64_t n_;
 
     Matrix();
     Matrix(int64_t, int64_t);
     Matrix(const Matrix&);
-    Matrix& operator=(const Matrix&);
-    ~Matrix();
+    Matrix& operator=(Matrix);
+    Matrix(Matrix&&) = default;
+    void swap(Matrix &);
 
     void zero();
     void uniform(real);
@@ -41,6 +43,13 @@ class Matrix {
     void save(std::ostream&);
     void load(std::istream&);
 };
+
+}
+
+namespace std {
+
+template<>
+void swap<fasttext::Matrix>(fasttext::Matrix &lhs, fasttext::Matrix &rhs);
 
 }
 

--- a/src/model.cc
+++ b/src/model.cc
@@ -124,7 +124,7 @@ void Model::predict(const std::vector<int32_t>& input, int32_t k,
   assert(k > 0);
   heap.reserve(k + 1);
   computeHidden(input, hidden);
-  if (args_->loss == loss_name::hs) {
+  if (args_->loss == loss_type::hs) {
     dfs(k, 2 * osz_ - 2, 0.0, heap, hidden);
   } else {
     findKBest(k, heap, hidden, output);
@@ -180,16 +180,16 @@ void Model::update(const std::vector<int32_t>& input, int32_t target, real lr) {
   assert(target < osz_);
   if (input.size() == 0) return;
   computeHidden(input, hidden_);
-  if (args_->loss == loss_name::ns) {
+  if (args_->loss == loss_type::ns) {
     loss_ += negativeSampling(target, lr);
-  } else if (args_->loss == loss_name::hs) {
+  } else if (args_->loss == loss_type::hs) {
     loss_ += hierarchicalSoftmax(target, lr);
   } else {
     loss_ += softmax(target, lr);
   }
   nexamples_ += 1;
 
-  if (args_->model == model_name::sup) {
+  if (args_->model == model_type::sup) {
     grad_.mul(1.0 / input.size());
   }
   for (auto it = input.cbegin(); it != input.cend(); ++it) {
@@ -199,10 +199,10 @@ void Model::update(const std::vector<int32_t>& input, int32_t target, real lr) {
 
 void Model::setTargetCounts(const std::vector<int64_t>& counts) {
   assert(counts.size() == osz_);
-  if (args_->loss == loss_name::ns) {
+  if (args_->loss == loss_type::ns) {
     initTableNegatives(counts);
   }
-  if (args_->loss == loss_name::hs) {
+  if (args_->loss == loss_type::hs) {
     buildTree(counts);
   }
 }

--- a/src/model.cc
+++ b/src/model.cc
@@ -104,6 +104,9 @@ real Model::softmax(int32_t target, real lr) {
 void Model::computeHidden(const std::vector<int32_t>& input, Vector& hidden) const {
   assert(hidden.size() == hsz_);
   hidden.zero();
+  if (input.empty()) {
+    return;
+  }
   for (auto it = input.cbegin(); it != input.cend(); ++it) {
     hidden.addRow(*wi_, *it);
   }

--- a/src/vector.cc
+++ b/src/vector.cc
@@ -19,6 +19,9 @@
 #include "utils.h"
 
 namespace fasttext {
+Vector::Vector()
+  : m_(0), data_(nullptr) {
+}
 
 Vector::Vector(int64_t m)
   : m_(m), data_(new real[m]) {

--- a/src/vector.cc
+++ b/src/vector.cc
@@ -11,20 +11,32 @@
 
 #include <assert.h>
 
+#include <algorithm>
 #include <iomanip>
+#include <utility>
 
 #include "matrix.h"
 #include "utils.h"
 
 namespace fasttext {
 
-Vector::Vector(int64_t m) {
-  m_ = m;
-  data_ = new real[m];
+Vector::Vector(int64_t m)
+  : m_(m), data_(new real[m]) {
 }
 
-Vector::~Vector() {
-  delete[] data_;
+Vector::Vector(const Vector &other)
+  : Vector(other.m_) {
+  std::copy(
+    other.data_.get(),
+    other.data_.get() + other.m_,
+    data_.get()
+  );
+}
+
+Vector & Vector::operator=(Vector other)
+{
+  swap(other);
+  return *this;
 }
 
 int64_t Vector::size() const {
@@ -84,6 +96,13 @@ int64_t Vector::argmax() {
   return argmax;
 }
 
+void Vector::swap(Vector &other)
+{
+  using std::swap;
+  swap(m_, other.m_);
+  swap(data_, other.data_);
+}
+
 real& Vector::operator[](int64_t i) {
   return data_[i];
 }
@@ -99,6 +118,15 @@ std::ostream& operator<<(std::ostream& os, const Vector& v)
     os << v.data_[j] << ' ';
   }
   return os;
+}
+
+}
+
+namespace std {
+
+template<>
+void swap<fasttext::Vector>(fasttext::Vector &lhs, fasttext::Vector &rhs) {
+  lhs.swap(rhs);
 }
 
 }

--- a/src/vector.h
+++ b/src/vector.h
@@ -26,6 +26,7 @@ class Vector {
     int64_t m_;
     std::unique_ptr<real[]> data_;
 
+    Vector();
     explicit Vector(int64_t);
     Vector(const Vector &);
     Vector& operator=(Vector);

--- a/src/vector.h
+++ b/src/vector.h
@@ -11,6 +11,7 @@
 #define FASTTEXT_VECTOR_H
 
 #include <cstdint>
+#include <memory>
 #include <ostream>
 
 #include "real.h"
@@ -23,10 +24,13 @@ class Vector {
 
   public:
     int64_t m_;
-    real* data_;
+    std::unique_ptr<real[]> data_;
 
     explicit Vector(int64_t);
-    ~Vector();
+    Vector(const Vector &);
+    Vector& operator=(Vector);
+    Vector(Vector &&) = default;
+    void swap(Vector&);
 
     real& operator[](int64_t);
     const real& operator[](int64_t) const;
@@ -41,6 +45,13 @@ class Vector {
 };
 
 std::ostream& operator<<(std::ostream&, const Vector&);
+
+}
+
+namespace std {
+
+template<>
+void swap<fasttext::Vector>(fasttext::Vector &lhs, fasttext::Vector &rhs);
 
 }
 


### PR DESCRIPTION
Besides a few small fixes, changes in this PR are mainly:
- Make core data structure objects (vectors & matrices) assignable, copyable, movable and swappable
- Decouple `FastText` class' prediction and vector printing code from `std::cout` and `std::cin`

These are useful when one wants to use a trained fastText model as part of another application (e.g. for real-time prediction), as opposed to only as a standalone command line tool. After the refactor, they just need to include `fasttext.h`, load the model file, and call `getWordVector`, `getTextVector`, or `predict` to get the output.
