### PR TITLE
Use const iterator in for range

### DIFF
--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -213,7 +213,7 @@ void Dictionary::threshold(int64_t t, int64_t tl) {
   for (int32_t i = 0; i < MAX_VOCAB_SIZE; i++) {
     word2int_[i] = -1;
   }
-  for (auto it = words_.begin(); it != words_.end(); ++it) {
+  for (auto it = words_.cbegin(); it != words_.cend(); ++it) {
     int32_t h = find(it->word);
     word2int_[h] = size_++;
     if (it->type == entry_type::word) nwords_++;

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -23,7 +23,7 @@ namespace fasttext {
 void FastText::getVector(Vector& vec, const std::string& word) {
   const std::vector<int32_t>& ngrams = dict_->getNgrams(word);
   vec.zero();
-  for (auto it = ngrams.begin(); it != ngrams.end(); ++it) {
+  for (auto it = ngrams.cbegin(); it != ngrams.cend(); ++it) {
     vec.addRow(*input_, *it);
   }
   if (ngrams.size() > 0) {
@@ -155,7 +155,7 @@ void FastText::test(std::istream& in, int32_t k) {
       std::vector<std::pair<real, int32_t>> modelPredictions;
       model_->predict(line, k, modelPredictions);
       for (auto it = modelPredictions.cbegin(); it != modelPredictions.cend(); it++) {
-        if (std::find(labels.begin(), labels.end(), it->second) != labels.end()) {
+        if (std::find(labels.cbegin(), labels.cend(), it->second) != labels.cend()) {
           precision += 1.0;
         }
       }


### PR DESCRIPTION
This PR uses the const iterator in `for` ranges whenever it is possible.