### PR TITLE
add print-args option to print saved args in a trained model

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -161,6 +161,22 @@ void Args::printHelp() {
     << std::endl;
 }
 
+void Args::print(std::ostream& out) {
+  out << "dim:          " << dim << std::endl;
+  out << "ws:           " << ws  << std::endl;
+  out << "epoch:        " << epoch  << std::endl;
+  out << "minCount:     " << minCount  << std::endl;
+  out << "neg:          " << neg  << std::endl;
+  out << "wordNgrams:   " << wordNgrams  << std::endl;
+  out << "model:        " << ((model==model_name::cbow)?"cbow":(model==model_name::sg?"sg":"sup")) << std::endl;
+  out << "loss:         " << ((loss==loss_name::hs)?"hs":(loss==loss_name::ns?"ns":"softmax")) << std::endl;
+  out << "bucket:       " << bucket  << std::endl;
+  out << "minn:         " << minn  << std::endl;
+  out << "maxn:         " << maxn  << std::endl;
+  out << "lrUpdateRate: " << lrUpdateRate  << std::endl;
+  out << "t:            " << t  << std::endl;
+}
+
 void Args::save(std::ostream& out) {
   out.write((char*) &(dim), sizeof(int));
   out.write((char*) &(ws), sizeof(int));

--- a/src/args.h
+++ b/src/args.h
@@ -47,6 +47,7 @@ class Args {
 
     void parseArgs(int, char**);
     void printHelp();
+    void print(std::ostream&);
     void save(std::ostream&);
     void load(std::istream&);
 };

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -103,6 +103,10 @@ void FastText::printInfo(real progress, real loss) {
   std::cout << std::flush;
 }
 
+void FastText::printArgs() {
+  args_->print(std::cout);
+}
+
 void FastText::supervised(Model& model, real lr,
                           const std::vector<int32_t>& line,
                           const std::vector<int32_t>& labels) {

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -42,7 +42,8 @@ class FastText {
     void loadModel(const std::string&);
     void loadModel(std::istream&);
     void printInfo(real, real);
-
+    void printArgs();
+    
     void supervised(Model&, real, const std::vector<int32_t>&,
                     const std::vector<int32_t>&);
     void cbow(Model&, real, const std::vector<int32_t>&);

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,6 +25,7 @@ void printUsage() {
     << "  skipgram            train a skipgram model\n"
     << "  cbow                train a cbow model\n"
     << "  print-vectors       print vectors given a trained model\n"
+    << "  print-args          print args given a trained model\n"
     << std::endl;
 }
 
@@ -49,6 +50,13 @@ void printPredictUsage() {
 void printPrintVectorsUsage() {
   std::cout
     << "usage: fasttext print-vectors <model>\n\n"
+    << "  <model>      model filename\n"
+    << std::endl;
+}
+
+void printPrintArgsUsage() {
+  std::cout
+    << "usage: fasttext print-args <model>\n\n"
     << "  <model>      model filename\n"
     << std::endl;
 }
@@ -128,6 +136,17 @@ void train(int argc, char** argv) {
   fasttext.train(a);
 }
 
+void printArgs(int argc, char** argv) {
+  if (argc != 3) {
+    printPrintArgsUsage();
+    exit(EXIT_FAILURE);
+  }
+  FastText fasttext;
+  fasttext.loadModel(std::string(argv[2]));
+  fasttext.printArgs();
+  exit(0);
+}
+
 int main(int argc, char** argv) {
   if (argc < 2) {
     printUsage();
@@ -142,6 +161,8 @@ int main(int argc, char** argv) {
     printVectors(argc, argv);
   } else if (command == "predict" || command == "predict-prob" ) {
     predict(argc, argv);
+  } else if (command == "print-args") {
+    printArgs(argc, argv);
   } else {
     printUsage();
     exit(EXIT_FAILURE);


### PR DESCRIPTION
With print-args one can print arguments stored in trained model. when you have multiple model files, this feature helps you find out about train arguments.