### PR TITLE
eta calculation bug in fuction printInfo

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -89,14 +89,14 @@ void FastText::loadModel(std::istream& in) {
 
 void FastText::printInfo(real progress, real loss) {
   real t = real(clock() - start) / CLOCKS_PER_SEC;
-  real wst = real(tokenCount) / t;
+  real ws = real(tokenCount) / t;
   real lr = args_->lr * (1.0 - progress);
   int eta = int(t / progress * (1 - progress));
   int etah = eta / 3600;
   int etam = (eta - etah * 3600) / 60;
   std::cout << std::fixed;
   std::cout << "\rProgress: " << std::setprecision(1) << 100 * progress << "%";
-  std::cout << "  words/sec/thread: " << std::setprecision(0) << wst;
+  std::cout << "  words/sec: " << std::setprecision(0) << ws;
   std::cout << "  lr: " << std::setprecision(6) << lr;
   std::cout << "  loss: " << std::setprecision(6) << loss;
   std::cout << "  eta: " << etah << "h" << etam << "m ";

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -91,7 +91,7 @@ void FastText::printInfo(real progress, real loss) {
   real t = real(clock() - start) / CLOCKS_PER_SEC;
   real wst = real(tokenCount) / t;
   real lr = args_->lr * (1.0 - progress);
-  int eta = int(t / progress * (1 - progress) / args_->thread);
+  int eta = int(t / progress * (1 - progress));
   int etah = eta / 3600;
   int etam = (eta - etah * 3600) / 60;
   std::cout << std::fixed;


### PR DESCRIPTION
Hi, I am researching the Fasttext currently and I found a bug after reviewing the code of Fasttext. I hope it will be helpful.
function **_printInfo_** in file fasttext.cc:

The **_eta_** should equals to **_int(t / progress * (1 - progress))_** instead of **int(t / progress * (1 - progress) / args_->thread)**. The **_progress_** is calculated by **real(tokenCount) / (args_->epoch * ntokens)** where **_tokenCount_** is contributed by all threads. That is the current progress is contributed by all threads and the **_eta_** should not divided by **_args_->thread_**. 
The **_real(tokenCount) / t_** calculate words/sec instead of words/sec/thread.