### PR TITLE
Clarify pretrained vectors command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The following arguments are optional:
   -t                  sampling threshold [0.0001]
   -label              labels prefix [__label__]
   -verbose            verbosity level [2]
-  -pretrainedVectors  pretrained word vectors for supervised learning []
+  -pretrainedVectors  pretrained word vectors (.vec) for supervised learning []
 ```
 
 Defaults may vary by mode. (Word-representation modes `skipgram` and `cbow` use a default `-minCount` of 5.)


### PR DESCRIPTION
It's not clear from the docs whether the .bin or .vec files should be used with `-pretrainedVectors` option (see https://github.com/facebookresearch/fastText/issues/108). This change clarifies that the .vec should be used (the error message given by the software when the .bin file is used instead is also not very clear).