### PR TITLE
Add word segmentation documentation for Chinese, Japanese, etc.

### DIFF
--- a/tutorials/unsupervised-learning.md
+++ b/tutorials/unsupervised-learning.md
@@ -35,6 +35,12 @@ anarchism originated as a term of abuse first used against early working class
 
 The text is nicely pre-processed and can be used to learn our word vectors. 
 
+For languages that do not use spaces to separate words in writing, such as Chinese, Japanese, Bhutanese, Khmer, Lao or Thai, you need an extra pre-processing step to separate words. We use the following tools to perform this word segmentation step:
+
+* Chinese: we use the Stanford Word Segmenter (with the CBT standard);
+* Japanese: we use Kuromoji;
+* Bhutanese, Khmer, Lao, Thai and Tibetan: we use the Word Instance Break Iterator from Java ICU. 
+
 # Training word vectors
 
 Learning  word vectors on this data can now be achieved with a single command:


### PR DESCRIPTION
Fixes #224 .
I wasn't sure whether or not to add the following comment.  I can add it if you want.

`Some languages, such as Vietnamese, often use spaces to separate syllables, so it might make sense to group syllables into words by replacing the "within-word" spaces with, say, underscores (e.g., using a library such as `pyvi`). We currently to not do this, though.
`