### PR TITLE
Functionality to save the model in binary form at every epoch and reload to continue training later

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -36,6 +36,7 @@ Args::Args() {
   label = "__label__";
   verbose = 2;
   pretrainedVectors = "";
+  loadFromModelBinFile = "";
   saveOutput = 0;
 
   qout = false;
@@ -120,6 +121,8 @@ void Args::parseArgs(int argc, char** argv) {
       verbose = atoi(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-pretrainedVectors") == 0) {
       pretrainedVectors = std::string(argv[ai + 1]);
+    } else if (strcmp(argv[ai], "-loadFromModelBinFile") == 0) {
+      loadFromModelBinFile = std::string(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-saveOutput") == 0) {
       saveOutput = atoi(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-qnorm") == 0) {

--- a/src/args.h
+++ b/src/args.h
@@ -44,6 +44,7 @@ class Args {
     std::string label;
     int verbose;
     std::string pretrainedVectors;
+    std::string loadFromModelBinFile;
     int saveOutput;
 
     bool qout;

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -54,9 +54,9 @@ class FastText {
     FastText();
 
     void getVector(Vector&, const std::string&);
-    void saveVectors();
-    void saveOutput();
-    void saveModel();
+    void saveVectors(std::string suffix = "");
+    void saveOutput(std::string suffix = "");
+    void saveModel(std::string suffix = "");
     void loadModel(std::istream&);
     void loadModel(const std::string&);
     void printInfo(real, real);
@@ -88,6 +88,14 @@ class FastText {
     void train(std::shared_ptr<Args>);
 
     void loadVectors(std::string);
+
+    void _saveVectors(std::string filename);
+
+    void _saveOutput(std::string filename);
+
+    void _saveModel(std::string fn);
+
+    void printSavingInfo(real progress, real loss, int current_epoch);
 };
 
 }

--- a/src/qmatrix.cc
+++ b/src/qmatrix.cc
@@ -31,7 +31,9 @@ QMatrix::QMatrix(const Matrix& mat, int32_t dsub, bool qnorm)
 }
 
 QMatrix::~QMatrix() {
-  delete[] codes_;
+    if (codesize_ != 0) {
+        delete[] codes_;
+    }
   if (qnorm_) { delete[] norm_codes_; }
 }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -10,6 +10,7 @@
 #include "utils.h"
 
 #include <ios>
+#include <sstream>
 
 namespace fasttext {
 
@@ -24,6 +25,13 @@ namespace utils {
     ifs.clear();
     ifs.seekg(std::streampos(pos));
   }
+
+    std::string format_epoch_suffix(int epoch_no) {
+        std::ostringstream stringStream;
+        stringStream << "-epoch-" << epoch_no;
+        std::string copyOfStr = stringStream.str();
+        return copyOfStr;
+    }
 }
 
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@ namespace utils {
 
   int64_t size(std::ifstream&);
   void seek(std::ifstream&, int64_t);
+    std::string format_epoch_suffix(int epoch_no);
 }
 
 }


### PR DESCRIPTION
I needed to train incrementally and test the performance at each epoch, so I added this functionality.

One can now use '-loadFromModelBinFile' option to load a pretrained model from a model file in binary format.

I couldn't test it extensively but I believe it should work.

Can you also take a look?

If you wish, I am willing to work further to modify the command line argument names, variable names etc.

BTW: I am also thinking of adding different learning rate schedules.