### PR TITLE
support different weight for each class in loss function

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -43,6 +43,7 @@ Args::Args() {
   qnorm = false;
   cutoff = 0;
   dsub = 2;
+  weightBalanced = false;
 }
 
 void Args::parseArgs(int argc, char** argv) {
@@ -132,6 +133,8 @@ void Args::parseArgs(int argc, char** argv) {
     cutoff = atoi(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-dsub") == 0) {
       dsub = atoi(argv[ai + 1]);
+    } else if (strcmp(argv[ai], "-weightBalanced") == 0) {
+      weightBalanced = true;
     } else {
       std::cerr << "Unknown argument: " << argv[ai] << std::endl;
       printHelp();

--- a/src/args.h
+++ b/src/args.h
@@ -52,6 +52,8 @@ class Args {
     size_t cutoff;
     size_t dsub;
 
+    bool weightBalanced;
+
     void parseArgs(int, char**);
     void printHelp();
     void save(std::ostream&);

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -62,7 +62,7 @@ class FastText {
     void printInfo(real, real);
 
     void supervised(Model&, real, const std::vector<int32_t>&,
-                    const std::vector<int32_t>&);
+                    const std::vector<int32_t>&, bool weightBalanced);
     void cbow(Model&, real, const std::vector<int32_t>&);
     void skipgram(Model&, real, const std::vector<int32_t>&);
     std::vector<int32_t> selectEmbeddings(int32_t) const;

--- a/src/model.h
+++ b/src/model.h
@@ -89,6 +89,7 @@ class Model {
     void findKBest(int32_t, std::vector<std::pair<real, int32_t>>&,
                    Vector&, Vector&) const;
     void update(const std::vector<int32_t>&, int32_t, real);
+    void update(const std::vector<int32_t>&, int32_t, real, const std::vector<real>&);
     void computeHidden(const std::vector<int32_t>&, Vector&) const;
     void computeOutputSoftmax(Vector&, Vector&) const;
     void computeOutputSoftmax();


### PR DESCRIPTION
see #141 

add a `-weightBalanced ` argument to enable the weight to be inversely proportional to number of instances in that class. After that, normalize the class weights again such that sum(class weights) = nlabels.

Code should be very straightforward, it only takes me couple of minutes. However I am not an c++ expert, so please let me know if there is any problem for example running speed:)