### PR TITLE
skip out-of-vocabulary words in sentenceVectors

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -375,11 +375,16 @@ void FastText::sentenceVectors() {
     int32_t count = 0;
     while(iss >> word) {
       getVector(vec, word);
-      vec.mul(1.0 / vec.norm());
-      svec.addVector(vec);
-      count++;
+      real norm = vec.norm();
+      if (norm > 0) {
+        vec.mul(1.0 / norm);
+        svec.addVector(vec);
+        count++;
+      }
     }
-    svec.mul(1.0 / count);
+    if (count > 0) {
+      svec.mul(1.0 / count);  
+    }
     std::cout << sentence << " " << svec << std::endl;
   }
 }


### PR DESCRIPTION
before this change, print-sentence-vector will emit nan results
when one of the word vectors has 0 norm (for instance, it's an
out-of-vocabulary word and word embeddings did not use char
n-grams)

to fix it, just omit terms with 0 norm