### PR TITLE
Fixed compilation issues on gcc-4.6.3

### DIFF
--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -25,7 +25,7 @@ const std::string Dictionary::EOW = ">";
 
 Dictionary::Dictionary(std::shared_ptr<Args> args) : args_(args),
   word2int_(MAX_VOCAB_SIZE, -1), size_(0), nwords_(0), nlabels_(0),
-  ntokens_(0) {}
+  ntokens_(0), pruneidx_size_(-1) {}
 
 int32_t Dictionary::find(const std::string& w) const {
   int32_t h = hash(w) % MAX_VOCAB_SIZE;

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -52,7 +52,7 @@ class Dictionary {
     int32_t nlabels_;
     int64_t ntokens_;
 
-    int64_t pruneidx_size_ = -1;
+    int64_t pruneidx_size_;
     std::unordered_map<int32_t, int32_t> pruneidx_;
     void addWordNgrams(
         std::vector<int32_t>& line,

--- a/src/productquantizer.h
+++ b/src/productquantizer.h
@@ -23,13 +23,13 @@ namespace fasttext {
 
 class ProductQuantizer {
   private:
-    const int32_t nbits_ = 8;
-    const int32_t ksub_ = 1 << nbits_;
-    const int32_t max_points_per_cluster_ = 256;
-    const int32_t max_points_ = max_points_per_cluster_ * ksub_;
-    const int32_t seed_ = 1234;
-    const int32_t niter_ = 25;
-    const real eps_ = 1e-7;
+    static const int32_t nbits_ = 8;
+    static const int32_t ksub_ = 1 << nbits_;
+    static const int32_t max_points_per_cluster_ = 256;
+    static const int32_t max_points_ = max_points_per_cluster_ * ksub_;
+    static const int32_t seed_ = 1234;
+    static const int32_t niter_ = 25;
+    static constexpr real eps_ = 1e-7;
 
     int32_t dim_;
     int32_t nsubq_;


### PR DESCRIPTION
The patch fixes compilation issues with gcc version 4.6.3 related to some unimplemented features like non-static data member initializer or non-static const members. This is important because 4.6.3 is a default version for Ubuntu 12.04 precise.