### PR TITLE
Print n-gram vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ It is possible to extract the trained n-gram vectors from a previously trained m
 To retrieve the n-gram vectors for a single word, use the following command:
 
 ```
-$ echo "word" | ./fasttext print-word-vectors model.bin
+$ echo "word" | ./fasttext print-ngrams model.bin
 ```
 
 This will output all n-gram vectors of the word to the standard output, one vector per line.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ $ ./fasttext test model.ftz test.txt
 The quantization procedure follows the steps described in [3](#fastext-zip). You can
 run the script `quantization-example.sh` for an example.
 
+### Obtaining n-gram vectors
+
+It is possible to extract the trained n-gram vectors from a previously trained model.
+To retrieve the n-gram vectors for a single word, use the following command:
+
+```
+$ echo "word" | ./fasttext print-word-vectors model.bin
+```
+
+This will output all n-gram vectors of the word to the standard output, one vector per line.
+This can also be used with a input file where each line contains one word:
+
+```
+$ cat queries.txt | ./fasttext print-ngrams model.bin
+```
+
+To extract all n-grams from a model:
+```
+$ cat model.vec | cut -d' ' -f 1 | sed 1d | ./fasttext print-ngrams model.bin | sort | uniq
+```
 
 ## Full documentation
 

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -390,6 +390,13 @@ void FastText::sentenceVectors() {
   }
 }
 
+void FastText::ngramVectors() {
+  std::string word;
+  while (std::cin >> word) {
+    ngramVectors(word);
+  }
+}
+
 void FastText::ngramVectors(std::string word) {
   std::vector<int32_t> ngrams;
   std::vector<std::string> substrings;

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -75,6 +75,7 @@ class FastText {
         std::vector<std::pair<real, std::string>>&) const;
     void wordVectors();
     void sentenceVectors();
+    void ngramVectors();
     void ngramVectors(std::string);
     void textVectors();
     void printWordVectors();

--- a/src/main.cc
+++ b/src/main.cc
@@ -188,13 +188,13 @@ void printSentenceVectors(int argc, char** argv) {
 }
 
 void printNgrams(int argc, char** argv) {
-  if (argc != 4) {
+  if (argc != 3) {
     printPrintNgramsUsage();
     exit(EXIT_FAILURE);
   }
   FastText fasttext;
   fasttext.loadModel(std::string(argv[2]));
-  fasttext.ngramVectors(std::string(argv[3]));
+  fasttext.ngramVectors();
   exit(0);
 }
 


### PR DESCRIPTION
Extension of `print-ngrams` to extract multiple n-gram vectors at once. Work around until a real solution is added to circumvent the hashing problem.
Issues: #21, #121, #282