### PR TITLE
Added support for saving softmax weights in supervised case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The following arguments are mandatory:
   -thread             number of threads [12]
   -pretrainedVectors  pretrained word vectors for supervised learning []
   -saveOutput         whether output params should be saved [0]
+  -saveSoftmax        whether softmax layer params should be saved in plaintext [0]
 
   The following arguments for quantization are optional:
   -cutoff             number of words and ngrams to retain [0]

--- a/src/args.cc
+++ b/src/args.cc
@@ -37,6 +37,7 @@ Args::Args() {
   verbose = 2;
   pretrainedVectors = "";
   saveOutput = 0;
+  saveSoftmax = 0;
 
   qout = false;
   retrain = false;
@@ -122,6 +123,8 @@ void Args::parseArgs(int argc, char** argv) {
       pretrainedVectors = std::string(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-saveOutput") == 0) {
       saveOutput = atoi(argv[ai + 1]);
+    } else if (strcmp(argv[ai], "-saveSoftmax") == 0) {
+      saveSoftmax = atoi(argv[ai + 1]);
     } else if (strcmp(argv[ai], "-qnorm") == 0) {
       qnorm = true; ai--;
     } else if (strcmp(argv[ai], "-retrain") == 0) {
@@ -191,7 +194,8 @@ void Args::printTrainingHelp() {
     << "  -loss               loss function {ns, hs, softmax} [ns]\n"
     << "  -thread             number of threads [" << thread << "]\n"
     << "  -pretrainedVectors  pretrained word vectors for supervised learning ["<< pretrainedVectors <<"]\n"
-    << "  -saveOutput         whether output params should be saved [" << saveOutput << "]\n";
+    << "  -saveOutput         whether output params should be saved [" << saveOutput << "]\n"
+    << "  -saveSoftmax        whether softmax layer params should we saved [" << saveOutput << "]\n";
 }
 
 void Args::printQuantizationHelp() {

--- a/src/args.cc
+++ b/src/args.cc
@@ -195,7 +195,7 @@ void Args::printTrainingHelp() {
     << "  -thread             number of threads [" << thread << "]\n"
     << "  -pretrainedVectors  pretrained word vectors for supervised learning ["<< pretrainedVectors <<"]\n"
     << "  -saveOutput         whether output params should be saved [" << saveOutput << "]\n"
-    << "  -saveSoftmax        whether softmax layer params should we saved [" << saveOutput << "]\n";
+    << "  -saveSoftmax        whether softmax layer params should be saved [" << saveOutput << "]\n";
 }
 
 void Args::printQuantizationHelp() {

--- a/src/args.cc
+++ b/src/args.cc
@@ -195,7 +195,7 @@ void Args::printTrainingHelp() {
     << "  -thread             number of threads [" << thread << "]\n"
     << "  -pretrainedVectors  pretrained word vectors for supervised learning ["<< pretrainedVectors <<"]\n"
     << "  -saveOutput         whether output params should be saved [" << saveOutput << "]\n"
-    << "  -saveSoftmax        whether softmax layer params should be saved [" << saveOutput << "]\n";
+    << "  -saveSoftmax        whether softmax layer params should be saved [" << saveSoftmax << "]\n";
 }
 
 void Args::printQuantizationHelp() {

--- a/src/args.h
+++ b/src/args.h
@@ -45,6 +45,7 @@ class Args {
     int verbose;
     std::string pretrainedVectors;
     int saveOutput;
+    int saveSoftmax;
 
     bool qout;
     bool retrain;

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -69,6 +69,23 @@ void FastText::saveOutput() {
   ofs.close();
 }
 
+void FastText::saveSoftmaxWeights() {
+  std::ofstream ofs(args_->output + ".softmax");
+  if (!ofs.is_open()) {
+    std::cerr << "Error opening file for saving softmax weights." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  ofs << dict_->nlabels() << " " << args_->dim << std::endl;
+  Vector vec(args_->dim);
+  for (int32_t i = 0; i < dict_->nlabels(); i++) {
+    std::string label = dict_->getLabel(i);
+    vec.zero();
+    vec.addRow(*output_, i);
+    ofs << label << " " << vec << std::endl;
+  }
+  ofs.close();
+}
+
 bool FastText::checkModel(std::istream& in) {
   int32_t magic;
   int32_t version;
@@ -646,6 +663,9 @@ void FastText::train(std::shared_ptr<Args> args) {
     if (args_->saveOutput > 0) {
       saveOutput();
     }
+  }
+  if (args_->saveSoftmax > 0 and args_->model == model_name::sup) {
+      saveSoftmaxWeights();
   }
 }
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -56,6 +56,7 @@ class FastText {
     void getVector(Vector&, const std::string&) const;
     void saveVectors();
     void saveOutput();
+    void saveSoftmaxWeights();
     void saveModel();
     void loadModel(std::istream&);
     void loadModel(const std::string&);


### PR DESCRIPTION
The output layer of a supervised classifier often contains useful information, e.g., embeddings of the labels. This PR adds support for saving the output layer matrix for supervised fastText models in plaintext. A good use-case of this update is: if you want label embeddings for free.