### PR TITLE
Allow looking up word for a given vector from command-line tool - issue 304

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -19,6 +19,7 @@
 #include <vector>
 #include <queue>
 #include <algorithm>
+#include <iterator>
 
 
 namespace fasttext {
@@ -512,6 +513,36 @@ void FastText::analogies(int32_t k) {
 
     findNN(wordVectors, query, k, banSet);
     std::cout << "Query triplet (A - B + C)? ";
+  }
+}
+
+void FastText::matchVector(int32_t k) {
+  std::string queryVectorString;
+  Vector queryVec(args_->dim);
+  Matrix wordVectors(dict_->nwords(), args_->dim);
+  precomputeWordVectors(wordVectors);
+  std::set<std::string> banSet;
+  std::cout << "Query vector?";
+  while (std::getline(std::cin, queryVectorString)) {
+    // Break the string apart into floats. We do this seperately so that we can check for validity.
+    std::vector<float> floats;
+    std::istringstream iss(queryVectorString);
+    std::copy(std::istream_iterator<float>(iss), std::istream_iterator<float>(), std::back_inserter(floats));
+
+    // Check to ensure provided vector has the correct dimensionalities
+    if (floats.size() != args_->dim) {
+      std::cerr << "The provided vector has only " << floats.size() << " dimensions, but the trained model requires vectors with " << args_->dim<< "dimensions." << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+    // Copy into fasttext vector object
+    for (uint64_t i = 0; i < args_->dim && i < floats.size(); i += 1) {
+        queryVec.data_[i] = floats[i];
+    }
+
+    // Perform nearest neighbor and print result
+    findNN(wordVectors, queryVec, k, banSet);
+    std::cout << "Query vector? ";
   }
 }
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -84,6 +84,7 @@ class FastText {
                 const std::set<std::string>&);
     void nn(int32_t);
     void analogies(int32_t);
+    void matchVector(int32_t);
     void trainThread(int32_t);
     void train(std::shared_ptr<Args>);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,6 +29,7 @@ void printUsage() {
     << "  print-sentence-vectors  print sentence vectors given a trained model\n"
     << "  nn                      query for nearest neighbors\n"
     << "  analogies               query for analogies\n"
+    << "  match-vector            query for the nearest words to a vector\n"
     << std::endl;
 }
 
@@ -102,6 +103,14 @@ void printNNUsage() {
 void printAnalogiesUsage() {
   std::cout
     << "usage: fasttext analogies <model> <k>\n\n"
+    << "  <model>      model filename\n"
+    << "  <k>          (optional; 10 by default) predict top k labels\n"
+    << std::endl;
+}
+
+void printMatchVectorUsage() {
+  std::cout
+    << "usage: fasttext match-word <model> <k>\n\n"
     << "  <model>      model filename\n"
     << "  <k>          (optional; 10 by default) predict top k labels\n"
     << std::endl;
@@ -230,6 +239,22 @@ void analogies(const std::vector<std::string> args) {
   exit(0);
 }
 
+void matchVector(const std::vector<std::string> args) {
+  int32_t k;
+  if (args.size() == 3) {
+    k = 10;
+  } else if (args.size() == 4) {
+    k = std::stoi(args[3]);
+  } else {
+    printMatchVectorUsage();
+    exit(EXIT_FAILURE);
+  }
+  FastText fasttext;
+  fasttext.loadModel(std::string(args[2]));
+  fasttext.matchVector(k);
+  exit(0);
+}
+
 void train(const std::vector<std::string> args) {
   std::shared_ptr<Args> a = std::make_shared<Args>();
   a->parseArgs(args);
@@ -260,6 +285,8 @@ int main(int argc, char** argv) {
     nn(args);
   } else if (command == "analogies") {
     analogies(args);
+  } else if (command == "match-vector") {
+    matchVector(args);
   } else if (command == "predict" || command == "predict-prob" ) {
     predict(args);
   } else {


### PR DESCRIPTION
Added in functionality to the command line tool allowing you to lookop the nearest word for a given vector. Effectively the inverse of print-word-vectors.