### PR TITLE
Update supervised-learning.md for  event not found error

### DIFF
--- a/tutorials/supervised-learning.md
+++ b/tutorials/supervised-learning.md
@@ -143,7 +143,7 @@ The model obtained by running fastText with the default arguments is pretty bad 
 Looking at the data, we observe that some words contain uppercase letter or punctuation. One of the first step to improve the performance of our model is to apply some simple pre-processing. A crude normalization can be obtained using command line tools such as `sed` and `tr`:
 
 ```
->> cat cooking.stackexchange.txt | sed -e "s/([.!?,'/()])/ 1 /g" | tr "[:upper:]" "[:lower:]" > cooking.preprocessed.txt
+>> cat cooking.stackexchange.txt | sed -e "s/([.\!?,'/()])/ 1 /g" | tr "[:upper:]" "[:lower:]" > cooking.preprocessed.txt
 >> head -n 12404 cooking.preprocessed.txt > cooking.train
 >> tail -n 3000 cooking.preprocessed.txt > cooking.valid 
 ```


### PR DESCRIPTION
cat cooking.stackexchange.txt | sed -e "s/([.!?,'/()])/ 1 /g" | tr "[:upper:]" "[:lower:]" > cooking.preprocessed.txt
this line of code has below error ,
-bash: !?,'/()])/ 1 /g" > cooking.preprocessed.txt: event not found
 the ! is being interpreted to fix this use bash:
With csh the ! used for command history reference and it works even inside a pair of apostrophes ' or quotation marks ", unless escaped with a backslash \.