### PR TITLE
Correctly escape curlybrace in icons and tables regexp

### DIFF
--- a/get-wikimedia.sh
+++ b/get-wikimedia.sh
@@ -30,7 +30,7 @@ read -r -p "Choose a language (e.g. en, bh, fr, etc.): " choice
 LANG="$choice"
 echo "Chosen language: ""$LANG"
 read -r -p "Continue to download (WARNING: This might be big and can take a long time!)(y/n)? " choice
-case "$choice" in 
+case "$choice" in
   y|Y ) echo "Starting download...";;
   n|N ) echo "Exiting";exit 1;;
   * ) echo "Invalid answer";exit 1;;
@@ -67,7 +67,7 @@ while (<>) {
     s/\[\[category:([^|\]]*)[^]]*\]\]/[[$1]]/ig;  # show categories without markup
     s/\[\[[a-z\-]*:[^\]]*\]\]//g;  # remove links to other languages
     s/\[\[[^\|\]]*\|/[[/g;  # remove wiki url, preserve visible text
-    s/{{[^}]*}}//g;         # remove {{icons}} and {tables}
+    s/{\{[^}]*}}//g;         # remove {{icons}} and {tables}
     s/{[^}]*}//g;
     s/\[//g;                # remove [ and ]
     s/\]//g;
@@ -77,4 +77,4 @@ while (<>) {
     print $_;
   }
 }
-' | normalize_text | awk '{if (NF>1) print;}' | tr -s " " | shuf > "${ROOT}"/wiki."${LANG}".txt 
+' | normalize_text | awk '{if (NF>1) print;}' | tr -s " " | shuf > "${ROOT}"/wiki."${LANG}".txt


### PR DESCRIPTION
Running `./get-wikimedia.sh` fails with this:

```
Saving data in data/wikimedia/20170913
Choose a language (e.g. en, bh, fr, etc.): sw
Chosen language: sw
Continue to download (WARNING: This might be big and can take a long time!)(y/n)? y
Starting download...
--2017-09-13 18:34:54--  https://dumps.wikimedia.org/swwiki/latest/swwiki-latest-pages-articles.xml.bz2
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving dumps.wikimedia.org... 208.80.154.11
Connecting to dumps.wikimedia.org|208.80.154.11|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 22547852 (22M) [application/octet-stream]
Saving to: ‘data/wikimedia/20170913/swwiki-latest-pages-articles.xml.bz2’

swwiki-latest-pages-articles.xml.bz2       100%[======================================================================================>]  21.50M  1.98MB/s    in 11s     

2017-09-13 18:35:07 (1.89 MB/s) - ‘data/wikimedia/20170913/swwiki-latest-pages-articles.xml.bz2’ saved [22547852/22547852]

Processing data/wikimedia/20170913/swwiki-latest-pages-articles.xml.bz2
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/{{ <-- HERE [^}]*}}/ at -e line 31.

```