### PR TITLE
Fix the get_sentence_vector's get_dimension 

### DIFF
--- a/python/fastText/FastText.py
+++ b/python/fastText/FastText.py
@@ -63,7 +63,7 @@ class _FastText():
                 "predict processes one line at a time (remove \'\\n\')"
             )
         text += "\n"
-        dim = self.f.get_dimension()
+        dim = self.get_dimension()
         b = fasttext.Vector(dim)
         self.f.getSentenceVector(b, text)
         return np.array(b)


### PR DESCRIPTION
Hello, I  find the get_sentence_vector function is not work in the Python interface. The get_sentence_vector's get_dimension  should remove the ' f.' .