### PR TITLE
Fixed sigmoid

### DIFF
--- a/src/model.cc
+++ b/src/model.cc
@@ -200,7 +200,7 @@ void Model::dfs(int32_t k, int32_t node, real score,
   } else {
     f= wo_->dotRow(hidden, node - osz_);
   }
-  f = 1. / (1 + std::exp(f));
+  f = 1. / (1 + std::exp(-f));
 
   dfs(k, tree[node].left, score + std_log(1.0 - f), heap, hidden);
   dfs(k, tree[node].right, score + std_log(f), heap, hidden);


### PR DESCRIPTION
Commit  https://github.com/facebookresearch/fastText/commit/4a8488df2ffd5b71f9d7123661627a1e14b02829 broke -loss hs due to a missing minus sign in the sigmoid function.