### PR TITLE
Remove useless directives in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ project(fasttext)
 set (fasttext_VERSION_MAJOR 0)
 set (fasttext_VERSION_MINOR 1)
 
-include_directories(fasttext)
-
 set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
 
 set(HEADER_FILES
@@ -34,7 +32,6 @@ set(SOURCE_FILES
     src/args.cc
     src/dictionary.cc
     src/fasttext.cc
-    src/main.cc
     src/matrix.cc
     src/model.cc
     src/productquantizer.cc


### PR DESCRIPTION
Hello,

Here is a simple pull request that cleans up the CMakeLists.txt.
This file, currently:
* builds the fastText library and include the main() function (and its helpers) into the .a or .so.
* has a useless include directory (There are other directives to create the "include/fasttext" directory when the project is installed.)

Vincent