### PR TITLE
Fix case where all results are below threshold (fixes #503)

### DIFF
--- a/python/fastText/FastText.py
+++ b/python/fastText/FastText.py
@@ -135,6 +135,8 @@ class _FastText():
         else:
             text = check(text)
             pairs = self.f.predict(text, k, threshold)
+            if not pairs:
+                return ()
             probs, labels = zip(*pairs)
             return labels, np.array(probs, copy=False)
 


### PR DESCRIPTION
Before this change, if all results were below the threshold a ValueError
would be raised when attempting to unpack the zipped lists. Instead it
will now return an empty tuple.