### PR TITLE
Miscellaneous: Adding additional git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,42 @@
 data
 fasttext
 result
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.pytest_cache/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/


### PR DESCRIPTION
## Summary
There are a number of files and folders created during the python install or testing processes that are not version controlled. This pull request adds them to `.gitignore` along with some other common files.