### PR TITLE
Two modifications for python

### DIFF
--- a/python/fastText/FastText.py
+++ b/python/fastText/FastText.py
@@ -286,7 +286,6 @@ def _build_args(args):
     for (k, v) in args.items():
         setattr(a, k, v)
     a.output = ""  # User should use save_model
-    a.pretrainedVectors = ""  # Unsupported
     a.saveOutput = 0  # Never use this
     if a.wordNgrams <= 1 and a.maxn == 0:
         a.bucket = 0

--- a/python/fastText/pybind/fasttext_pybind.cc
+++ b/python/fastText/pybind/fasttext_pybind.cc
@@ -294,7 +294,6 @@ PYBIND11_MODULE(fasttext_pybind, m) {
             }
             return all_predictions;
           })
-      .def("isQuant", [](fasttext::FastText& m) { return m.isQuant(); })
       .def(
           "getWordId",
           [](fasttext::FastText& m, const std::string word) {


### PR DESCRIPTION
1) Remove duplicate isQuant defination in fasttext_pybing.cc.
2) allow passing arg of pretrainedVectors to train in the python env.