### PR TITLE
Fix link to crawl vectors to prevent 404

### DIFF
--- a/docs/en/pretrained-vectors.html
+++ b/docs/en/pretrained-vectors.html
@@ -14,7 +14,7 @@
           };
         </script></nav></div><div class="container mainContainer"><div class="wrapper"><div class="post"><header class="postHeader"><h1>Wiki word vectors</h1></header><article><div><span><p>We are publishing pre-trained word vectors for 294 languages, trained on <a href="https://www.wikipedia.org"><em>Wikipedia</em></a> using fastText.
 These vectors in dimension 300 were obtained using the skip-gram model described in <a href="https://arxiv.org/abs/1607.04606"><em>Bojanowski et al. (2016)</em></a> with default parameters.</p>
-<p>Please note that a newer version of multi-lingual word vectors are available at: [<a href="https://fasttext.cc/docs/en/crawl-vectors.html]">https://fasttext.cc/docs/en/crawl-vectors.html]</a>.</p>
+<p>Please note that a newer version of multi-lingual word vectors are available at: [<a href="https://fasttext.cc/docs/en/crawl-vectors.html">https://fasttext.cc/docs/en/crawl-vectors.html</a>].</p>
 <h3><a class="anchor" aria-hidden="true" id="models"></a><a href="#models" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>Models</h3>
 <p>The models can be downloaded from:</p>
 <table>


### PR DESCRIPTION
Currently, on the pretrained-vectors page, when you click on the link for crawl vectors it brings you to `https://fasttext.cc/docs/en/crawl-vectors.html]`, a page that does not exist. All this PR does is fix this link, to correctly route the user and prevent a 404. 