### PR TITLE
Avoid memory overrun in python 3

### DIFF
--- a/docs/english-vectors.md
+++ b/docs/english-vectors.md
@@ -28,7 +28,7 @@ def load_vectors(fname):
     data = {}
     for line in fin:
         tokens = line.rstrip().split(' ')
-        data[tokens[0]] = map(float, tokens[1:])
+        data[tokens[0]] = [float(x) for x in tokens[1:]])
     return data
 ```
 


### PR DESCRIPTION
Python 3 uses lazy evaluation for map calls. When using for simple tasks like type casting, this can lead to memory overuse as found when loading in .vec files here. This becomes a problem when loading very large dictionaries. To fix, converted map call to list comprehension.