### PR TITLE
footer language : default to EN

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -25,6 +25,7 @@ const githubButton = (
 
 class Footer extends React.Component {
   render() {
+    const language = this.props.language || "en";
     const currentYear = new Date().getFullYear();
     return (
       <footer className="nav-footer" id="footer">
@@ -39,7 +40,7 @@ class Footer extends React.Component {
             <h5>Support</h5>
             <a
               href={
-                this.props.config.baseUrl + "docs/" + this.props.language + "/support.html"
+                this.props.config.baseUrl + "docs/" + language + "/support.html"
               }
             >
               Getting Started
@@ -48,7 +49,7 @@ class Footer extends React.Component {
               href={
                 this.props.config.baseUrl +
                 "docs/" +
-                this.props.language +
+                language +
                 "/supervised-tutorial.html"
               }
             >
@@ -58,7 +59,7 @@ class Footer extends React.Component {
               href={
                 this.props.config.baseUrl +
                 "docs/" +
-                this.props.language +
+                language +
                 "/faqs.html"
               }
             >
@@ -68,7 +69,7 @@ class Footer extends React.Component {
               href={
                 this.props.config.baseUrl +
                 "docs/" +
-                this.props.language +
+                language +
                 "/api.html"
               }
             >


### PR DESCRIPTION
Hi

Looks like in some cases the `language` is not defined which result in 404 links.

<img width="398" alt="capture d ecran 2018-07-23 a 00 24 32" src="https://user-images.githubusercontent.com/124937/43050768-e1209046-8e0e-11e8-8510-beed7b549633.png">

This fix defaults the language to `en`