### PR TITLE
Fix error 'cl.exe failed with exit status 2' in win10 using 'pip inst…

### DIFF
--- a/src/productquantizer.cc
+++ b/src/productquantizer.cc
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 
 namespace fasttext {
 


### PR DESCRIPTION
Fix error 'cl.exe failed with exit status 2' in win10 using 'pip install'