### PR TITLE
Fix error C3861 on Windows

### DIFF
--- a/src/productquantizer.h
+++ b/src/productquantizer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstring>
+#include <string>
 #include <istream>
 #include <ostream>
 #include <vector>


### PR DESCRIPTION
`#include <string>` enables `std::to_string()` in productquantizer.cc for Windows and does not break anything else, for the looks of it.
Is a part of a proposed solution to #411