### PR TITLE
Repair python build

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -412,6 +412,30 @@ void FastText::predict(
 void FastText::predict(
     std::istream& in,
     int32_t k,
+    std::vector<std::pair<real, std::string>>& predictions,
+    real threshold) const {
+  std::vector<int32_t> words, labels;
+  predictions.clear();
+  dict_->getLine(in, words, labels);
+  predictions.clear();
+  if (words.empty()) {
+    return;
+  }
+  Vector hidden(args_->dim);
+  Vector output(dict_->nlabels());
+  std::vector<std::pair<real, int32_t>> modelPredictions;
+  model_->predict(words, k, threshold, modelPredictions, hidden, output);
+  for (auto it = modelPredictions.cbegin(); it != modelPredictions.cend();
+       it++) {
+    predictions.push_back(
+        std::make_pair(it->first, dict_->getLabel(it->second)));
+  }
+}
+
+
+void FastText::predict(
+    std::istream& in,
+    int32_t k,
     bool print_prob,
     real threshold) {
   std::vector<std::pair<real, int32_t>> predictions;

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -106,6 +106,11 @@ class FastText {
   void quantize(const Args);
   std::tuple<int64_t, double, double> test(std::istream&, int32_t, real = 0.0);
   void predict(std::istream&, int32_t, bool, real = 0.0);
+  void predict(
+      std::istream&,
+      int32_t,
+      std::vector<std::pair<real, std::string>>&,
+      real = 0.0) const;
   void printLabelStats(std::istream&, int32_t, real = 0.0) const;
   void ngramVectors(std::string);
   void precomputeWordVectors(Matrix&);


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/fastText/issues/670

**Summary**
A definition for FastText::predict() was rewritten to support new features, but existing calls to the old function definition were not changed accordingly.  This fix simply re-adds the old function definition to the project so that both definitions of FastText::predict() can be called.

This fix intends to maintain support for the features introduced in https://github.com/facebookresearch/fastText/commit/be1e597cb67c069ba9940ff241d9aad38ccd37da