### PR TITLE
Refactor model testing and metrics code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(HEADER_FILES
     src/dictionary.h
     src/fasttext.h
     src/matrix.h
+    src/metrics.h
     src/model.h
     src/productquantizer.h
     src/qmatrix.h
@@ -36,6 +37,7 @@ set(SOURCE_FILES
     src/fasttext.cc
     src/main.cc
     src/matrix.cc
+    src/metrics.cc
     src/model.cc
     src/productquantizer.cc
     src/qmatrix.cc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 CXX = c++
 CXXFLAGS = -pthread -std=c++0x -march=native
-OBJS = args.o dictionary.o productquantizer.o matrix.o qmatrix.o vector.o model.o utils.o fasttext.o
+OBJS = args.o dictionary.o productquantizer.o matrix.o qmatrix.o vector.o model.o utils.o metrics.o fasttext.o
 INCLUDES = -I.
 
 opt: CXXFLAGS += -O3 -funroll-loops
@@ -41,6 +41,9 @@ model.o: src/model.cc src/model.h src/args.h
 
 utils.o: src/utils.cc src/utils.h
 	$(CXX) $(CXXFLAGS) -c src/utils.cc
+
+metrics.o: src/metrics.cc src/metrics.h
+	$(CXX) $(CXXFLAGS) -c src/metrics.cc
 
 fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc

--- a/python/fastText/pybind/fasttext_pybind.cc
+++ b/python/fastText/pybind/fasttext_pybind.cc
@@ -150,9 +150,11 @@ PYBIND11_MODULE(fasttext_pybind, m) {
             if (!ifs.is_open()) {
               throw std::invalid_argument("Test file cannot be opened!");
             }
-            std::tuple<int64_t, double, double> result = m.test(ifs, k);
+            fasttext::MetricsAccumulator metricsAccumulator;
+            m.test(ifs, k, 0.0, metricsAccumulator);
             ifs.close();
-            return result;
+            const auto& metrics = metricsAccumulator.metrics();
+            return std::tuple<int64_t, double, double>(metrics.numExamples, metrics.precision(), metrics.recall());
           })
       .def(
           "getSentenceVector",

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -369,31 +369,22 @@ void FastText::skipgram(
   }
 }
 
-std::tuple<int64_t, double, double>
-FastText::test(std::istream& in, int32_t k, real threshold) {
-  int32_t nexamples = 0, nlabels = 0, npredictions = 0;
-  double precision = 0.0;
-  std::vector<int32_t> line, labels;
+void FastText::test(std::istream& in, int32_t k, real threshold, MetricsAccumulator& accumulator) {
+  std::vector<int32_t> line;
+  std::vector<int32_t> labels;
+  std::vector<std::pair<real, int32_t>> predictions;
 
   while (in.peek() != EOF) {
+    line.clear();
+    labels.clear();
     dict_->getLine(in, line, labels);
-    if (labels.size() > 0 && line.size() > 0) {
-      std::vector<std::pair<real, int32_t>> modelPredictions;
-      model_->predict(line, k, threshold, modelPredictions);
-      for (auto it = modelPredictions.cbegin(); it != modelPredictions.cend();
-           it++) {
-        if (std::find(labels.begin(), labels.end(), it->second) !=
-            labels.end()) {
-          precision += 1.0;
-        }
-      }
-      nexamples++;
-      nlabels += labels.size();
-      npredictions += modelPredictions.size();
+
+    if (!labels.empty() && !line.empty()) {
+      predictions.clear();
+      predict(k, line, predictions, threshold);
+      accumulator.log(labels, predictions);
     }
   }
-  return std::tuple<int64_t, double, double>(
-      nexamples, precision / npredictions, precision / nlabels);
 }
 
 void FastText::predict(
@@ -435,75 +426,6 @@ void FastText::predict(
     }
     std::cout << std::endl;
   }
-}
-
-void FastText::printLabelStats(
-    const std::vector<LabelStats>& labelStats) const {
-  const static double kUnknownValue = -1.0;
-  auto computeF1Score = [](double precision, double recall) -> double {
-    if (precision == kUnknownValue || recall == kUnknownValue) {
-      return kUnknownValue;
-    }
-    if (precision != 0 && recall != 0) {
-      return 2 * precision * recall / (precision + recall);
-    }
-    return 0.;
-  };
-  auto displayScore = [](double value) {
-    std::cout << std::fixed;
-    std::cout.precision(6);
-    if (value == kUnknownValue) {
-      std::cout << "--------";
-    } else {
-      std::cout << value;
-    }
-  };
-
-  for (size_t labelId = 0; labelId < labelStats.size(); labelId++) {
-    const auto& labelStat = labelStats[labelId];
-    double precision = labelStat.predicted
-        ? ((double)labelStat.predictedGold / labelStat.predicted)
-        : kUnknownValue;
-    double recall = labelStat.gold
-        ? ((double)labelStat.predictedGold / labelStat.gold)
-        : kUnknownValue;
-    double f1score = computeF1Score(precision, recall);
-    std::cout << "F1-Score : ";
-    displayScore(f1score);
-    std::cout << "  Precision : ";
-    displayScore(precision);
-    std::cout << "  Recall : ";
-    displayScore(recall);
-    std::cout << "   " << dict_->getLabel(labelId) << std::endl;
-  }
-}
-
-void FastText::printLabelStats(std::istream& in, int32_t k, real threshold)
-    const {
-  std::vector<std::pair<real, int32_t>> predictions;
-  size_t labelsSize = dict_->nlabels();
-  std::vector<LabelStats> labelStats(labelsSize);
-  while (in.peek() != EOF) {
-    std::vector<int32_t> words, gold;
-    dict_->getLine(in, words, gold);
-    predictions.clear();
-    predict(k, words, predictions, threshold);
-    for (const auto& goldLabelId : gold) {
-      assert(goldLabelId < labelsSize);
-      labelStats[goldLabelId].gold++;
-    }
-    for (const auto& predictedLabel : predictions) {
-      int32_t predictedLabelId = predictedLabel.second;
-      assert(predictedLabelId < labelsSize);
-      labelStats[predictedLabelId].predicted++;
-      if (auto itFound =
-              std::find(gold.begin(), gold.end(), predictedLabelId) !=
-              gold.end()) {
-        labelStats[predictedLabelId].predictedGold++;
-      }
-    }
-  }
-  printLabelStats(labelStats);
 }
 
 void FastText::getSentenceVector(std::istream& in, fasttext::Vector& svec) {

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -22,6 +22,7 @@
 #include "args.h"
 #include "dictionary.h"
 #include "matrix.h"
+#include "metrics.h"
 #include "model.h"
 #include "qmatrix.h"
 #include "real.h"
@@ -53,13 +54,7 @@ class FastText {
   bool quant_;
   int32_t version;
 
-  struct LabelStats {
-    int32_t gold, predicted, predictedGold;
-    LabelStats() : gold(0), predicted(0), predictedGold(0) {}
-  };
-
   void startThreads();
-  void printLabelStats(const std::vector<LabelStats>& labelStats) const;
 
  public:
   FastText();
@@ -99,14 +94,13 @@ class FastText {
   std::vector<int32_t> selectEmbeddings(int32_t) const;
   void getSentenceVector(std::istream&, Vector&);
   void quantize(const Args);
-  std::tuple<int64_t, double, double> test(std::istream&, int32_t, real = 0.0);
+  void test(std::istream&, int32_t, real, MetricsAccumulator&);
   void predict(
       int32_t,
       const std::vector<int32_t>&,
       std::vector<std::pair<real, int32_t>>&,
       real = 0.0) const;
   void predict(std::istream&, int32_t, bool, real = 0.0);
-  void printLabelStats(std::istream&, int32_t, real = 0.0) const;
   void ngramVectors(std::string);
   void precomputeWordVectors(Matrix&);
   void findNN(

--- a/src/main.cc
+++ b/src/main.cc
@@ -130,37 +130,35 @@ void test(const std::vector<std::string>& args) {
     printTestUsage();
     exit(EXIT_FAILURE);
   }
-  int32_t k = 1;
-  real threshold = 0.0;
-  if (args.size() > 4) {
-    k = std::stoi(args[4]);
-    if (args.size() == 6) {
-      threshold = std::stof(args[5]);
-    }
-  }
+
+  const auto& model = args[2];
+  const auto& input = args[3];
+  int32_t k = args.size() > 4 ? std::stoi(args[4]) : 1;
+  real threshold = args.size() > 5 ? std::stof(args[5]) : 0;
 
   FastText fasttext;
-  fasttext.loadModel(args[2]);
+  fasttext.loadModel(model);
 
-  std::tuple<int64_t, double, double> result;
-  std::string infile = args[3];
-  if (infile == "-") {
-    result = fasttext.test(std::cin, k, threshold);
+  MetricsAccumulator metricsAccumulator;
+
+  if (input == "-") {
+    fasttext.test(std::cin, k, threshold, metricsAccumulator);
   } else {
-    std::ifstream ifs(infile);
+    std::ifstream ifs(input);
     if (!ifs.is_open()) {
       std::cerr << "Test file cannot be opened!" << std::endl;
       exit(EXIT_FAILURE);
     }
-    result = fasttext.test(ifs, k, threshold);
-    ifs.close();
+    fasttext.test(ifs, k, threshold, metricsAccumulator);
   }
-  std::cout << "N"
-            << "\t" << std::get<0>(result) << std::endl;
+
+  const auto& metrics = metricsAccumulator.metrics();
+
+  std::cout << "N" << "\t" << metrics.numExamples << std::endl;
   std::cout << std::setprecision(3);
-  std::cout << "P@" << k << "\t" << std::get<1>(result) << std::endl;
-  std::cout << "R@" << k << "\t" << std::get<2>(result) << std::endl;
-  std::cerr << "Number of examples: " << std::get<0>(result) << std::endl;
+  std::cout << "P@" << k << "\t" << metrics.precision() << std::endl;
+  std::cout << "R@" << k << "\t" << metrics.recall() << std::endl;
+  std::cout << "F1" << "\t" << metrics.f1Score() << std::endl;
 }
 
 void predict(const std::vector<std::string>& args) {
@@ -202,26 +200,36 @@ void printLabelStats(const std::vector<std::string>& args) {
     printPrintLabelStatsUsage();
     exit(EXIT_FAILURE);
   }
-  int32_t k = 1;
-  real threshold = 0.0;
-  if (args.size() > 4) {
-    k = std::stoi(args[4]);
-    if (args.size() > 5) {
-      threshold = std::stof(args[5]);
-    }
-  }
+
+  const auto& model = args[2];
+  const auto& input = args[3];
+  int32_t k = args.size() > 4 ? std::stoi(args[4]) : 1;
+  real threshold = args.size() > 5 ? std::stof(args[5]) : 0;
 
   FastText fasttext;
-  fasttext.loadModel(std::string(args[2]));
+  fasttext.loadModel(model);
 
-  std::string infile(args[3]);
-  std::ifstream ifs(infile);
-  if (!ifs.is_open()) {
-    std::cerr << "Input file cannot be opened!" << std::endl;
-    exit(EXIT_FAILURE);
+  LabelMetricsAccumulator metricsAccumulator;
+
+  if (input == "-") {
+    fasttext.test(std::cin, k, threshold, metricsAccumulator);
+  } else {
+    std::ifstream ifs(input);
+    if (!ifs.is_open()) {
+      std::cerr << "Test file cannot be opened!" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    fasttext.test(ifs, k, threshold, metricsAccumulator);
   }
-  fasttext.printLabelStats(ifs, k, threshold);
-  ifs.close();
+
+  metricsAccumulator.write(std::cout, fasttext.getDictionary());
+  const auto& metrics = metricsAccumulator.metrics();
+
+  std::cout << "N" << "\t" << metrics.numExamples << std::endl;
+  std::cout << std::setprecision(3);
+  std::cout << "P@" << k << "\t" << metrics.precision() << std::endl;
+  std::cout << "R@" << k << "\t" << metrics.recall() << std::endl;
+  std::cout << "F1" << "\t" << metrics.f1Score() << std::endl;
 
   exit(0);
 }

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -1,0 +1,73 @@
+#include "metrics.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+
+namespace fasttext {
+
+/* ----- MetricsAccumulator ----- */
+
+void MetricsAccumulator::log(const std::vector<int32_t>& labels,
+                             const std::vector<std::pair<real, int32_t>>& predictions) {
+  metrics_.numExamples++;
+  metrics_.numLabels += labels.size();
+  metrics_.numPredictions += predictions.size();
+  metrics_.numTruePositives +=
+      std::count_if(predictions.begin(), predictions.end(), [&](std::pair<real, int32_t> prediction) {
+        return std::find(labels.begin(), labels.end(), prediction.second) != labels.end();
+      });
+}
+
+/* ----- LabelMetricsAccumulator ----- */
+
+void LabelMetricsAccumulator::log(const std::vector<int32_t>& labels,
+                                  const std::vector<std::pair<real, int32_t>>& predictions) {
+  MetricsAccumulator::log(labels, predictions);
+
+  for (const auto& prediction: predictions) {
+    labelMetrics_[prediction.second].numPredictions++;
+
+    if (std::find(labels.begin(), labels.end(), prediction.second) != labels.end())
+      labelMetrics_[prediction.second].numTruePositives++;
+    else
+      labelMetrics_[prediction.second].numExamples++;
+  }
+
+  for (const auto& label : labels) {
+    labelMetrics_[label].numLabels++;
+    labelMetrics_[label].numExamples++;
+  }
+}
+
+void LabelMetricsAccumulator::write(std::ostream& out, std::shared_ptr<const Dictionary> dict) const {
+  out << std::fixed;
+  out << std::setprecision(6);
+
+  auto writeMetric = [&](const std::string& name, double value) {
+    out << name << " : ";
+    if (std::isfinite(value))
+      out << value;
+    else
+      out << "--------";
+    out << "  ";
+  };
+
+  for (int32_t i = 0; i < dict->nlabels(); i++) {
+    auto it = labelMetrics_.find(i);
+    if (it != labelMetrics_.end()) {
+      const auto& metrics = it->second;
+      writeMetric("F1-Score", metrics.f1Score());
+      writeMetric("Precision", metrics.precision());
+      writeMetric("Recall", metrics.recall());
+      out << " " << dict->getLabel(i) << std::endl;
+    } else {
+      writeMetric("F1-Score", NAN);
+      writeMetric("Precision", NAN);
+      writeMetric("Recall", NAN);
+      out << " " << dict->getLabel(i) << std::endl;
+    }
+  }
+}
+
+}

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+
+#include "real.h"
+#include "dictionary.h"
+
+namespace fasttext {
+
+struct Metrics {
+  uint64_t numExamples;
+  uint64_t numLabels;
+  uint64_t numPredictions;
+  uint64_t numTruePositives;
+
+  double precision() const { return numTruePositives / double(numPredictions); }
+  double recall() const { return numTruePositives / double(numLabels); }
+  double f1Score() const { return 2 * numTruePositives / double(numPredictions + numLabels); }
+};
+
+class MetricsAccumulator {
+ public:
+  virtual ~MetricsAccumulator() = default;
+  virtual void log(const std::vector<int32_t>& labels, const std::vector<std::pair<real, int32_t>>& predictions);
+  Metrics metrics() const { return metrics_; }
+
+ private:
+  Metrics metrics_{};
+};
+
+class LabelMetricsAccumulator : public MetricsAccumulator {
+ public:
+  void log(const std::vector<int32_t>& labels, const std::vector<std::pair<real, int32_t>>& predictions) override;
+  void write(std::ostream&, std::shared_ptr<const Dictionary>) const;
+
+ private:
+  std::unordered_map<int32_t, Metrics> labelMetrics_;
+};
+
+}


### PR DESCRIPTION
Recently, a diff from @Celebio added a new feature "test-label" that calculates precision/recall/f1-score for every label. This is very useful feature, however, it makes FastText class overcomplicated.
I propose a refactoring of model testing and metrics calculation code. It introduces MetricsAccumulator class, which is responsible for collecting stats on a dataset and calculating final metrics. Moving this functionality to separate class allows to simplify model testing code in FastText class. The same FastText::test method can be used to compute both regular and per-label metrics. This design allows MetricsAccumulator to be extended to implement different types of metrics. As result, it would be much easier to add other kinds of metrics in the future.