### PR TITLE
Fix compilation of python bindings under C++11.

### DIFF
--- a/python/fastText/pybind/fasttext_pybind.cc
+++ b/python/fastText/pybind/fasttext_pybind.cc
@@ -273,7 +273,7 @@ PYBIND11_MODULE(fasttext_pybind, m) {
                 predictions.begin(),
                 predictions.end(),
                 std::back_inserter(all_predictions),
-                [&d](const auto& prediction) {
+                [&d](const std::pair<fasttext::real, int32_t>& prediction) {
                   return std::pair<fasttext::real, std::string>(
                       std::exp(prediction.first),
                       d->getLabel(prediction.second));


### PR DESCRIPTION
Python bindings fail to compile under C++11 with following error:

```
    python/fastText/pybind/fasttext_pybind.cc: In lambda function:
    python/fastText/pybind/fasttext_pybind.cc:276:34: error: parameter declared ‘auto’
                     [&d](const auto& prediction) {
                                      ^
```

This happens because auto parameters for lambda functions are supported only starting from C++14.