### PR TITLE
Update get-wikimedia.sh for Perl 5.26

### DIFF
--- a/get-wikimedia.sh
+++ b/get-wikimedia.sh
@@ -66,7 +66,7 @@ while (<>) {
     s/\[\[category:([^|\]]*)[^]]*\]\]/[[$1]]/ig;  # show categories without markup
     s/\[\[[a-z\-]*:[^\]]*\]\]//g;  # remove links to other languages
     s/\[\[[^\|\]]*\|/[[/g;  # remove wiki url, preserve visible text
-    s/[{][{][^}]*}}//g;         # remove {{icons}} and {tables}
+    s/[{][{][^}]*}}//g;     # remove {{icons}} and {tables}
     s/[{][^}]*}//g;
     s/\[//g;                # remove [ and ]
     s/\]//g;


### PR DESCRIPTION
Starting with Perl 5.26, a literal "{" must be escaped in a pattern. From Perl 5.22 on it was raising a warning https://metacpan.org/pod/release/RJBS/perl-5.22.0/pod/perldelta.pod#A-literal-%22%7B%22-should-now-be-escaped-in-a-pattern