### PR TITLE
Handle lack of predictions in the Python interface (fixes #688 and #503)

### DIFF
--- a/python/fastText/FastText.py
+++ b/python/fastText/FastText.py
@@ -138,7 +138,10 @@ class _FastText():
         else:
             text = check(text)
             predictions = self.f.predict(text, k, threshold, on_unicode_error)
-            probs, labels = zip(*predictions)
+            if len(predictions) > 0:
+                probs, labels = zip(*predictions)
+            else:
+                probs, labels = [], []
 
             return labels, np.array(probs, copy=False)
 


### PR DESCRIPTION
In situation where all predictions were below set threshold Python interface raises `ValueError` exception.

Steps to reproduce:
```
model = fastText.load_model('model.bin')
result = model.predict('Example text', threshold=1.0)
```

Fix addresses bugs #688 and #503 