### PR TITLE
Fix setup.py on Ubuntu 18.04 (Python 3.6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ def _get_readme():
     Use pandoc to generate rst from md.
     pandoc --from=markdown --to=rst --output=python/README.rst python/README.md
     """
-    with open("python/README.rst") as fid:
+    with open("python/README.rst", encoding='utf-8') as fid:
         return fid.read()
 
 


### PR DESCRIPTION
**Issue:**

On Ubuntu 18.04 with Python 3.6.8, the `pip install fasttext` command fails with the latest updates to master. Equally, the `pip install .` command would fail after cloning locally.

It's an encoding issue:

```
# ---------------------- pip install . -----------------
Processing /fastText
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Collecting pybind11
      Downloading https://files.pythonhosted.org/packages/5d/85/c7a8dffda52ce25a8bcfe9a28b6861bdd52da59ae001fdd4173e054b7d9b/pybind11-2.3.0-py2.py3-none-any.whl (147kB)
    Installing collected packages: pybind11
    Successfully installed pybind11-2.3.0
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-n0a0bx12/setup.py", line 173, in <module>
        long_description=_get_readme(),
      File "/tmp/pip-req-build-n0a0bx12/setup.py", line 164, in _get_readme
        return fid.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1102: ordinal not in range(128)
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-n0a0bx12/
```

By setting the encoding explicitly it's not a problem.
This issue doesn't affect macOS.
