### PR TITLE
better default number of threads in c++ impl

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <thread>
 
 namespace fasttext {
 
@@ -29,7 +30,7 @@ Args::Args() {
   bucket = 2000000;
   minn = 3;
   maxn = 6;
-  thread = 12;
+  thread = (std::thread::hardware_concurrency() - 1 > 0) ? (std::thread::hardware_concurrency() - 1) : 12 ;
   lrUpdateRate = 100;
   t = 1e-4;
   label = "__label__";


### PR DESCRIPTION
This change ports https://github.com/facebookresearch/fastText/commit/501b9b1e4543fd2de55e4a621a9924ce7d2b5b17 to c++ impl, that defines better default number of threads.