### PR TITLE
Fix dependence issues in Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,40 +23,40 @@ debug: fasttext
 args.o: src/args.cc src/args.h
 	$(CXX) $(CXXFLAGS) -c src/args.cc
 
-matrix.o: src/matrix.cc src/matrix.h
+matrix.o: src/matrix.cc src/matrix.h src/real.h
 	$(CXX) $(CXXFLAGS) -c src/matrix.cc
 
-dictionary.o: src/dictionary.cc src/dictionary.h src/args.h
+dictionary.o: src/dictionary.cc src/dictionary.h src/args.h src/real.h
 	$(CXX) $(CXXFLAGS) -c src/dictionary.cc
 
-loss.o: src/loss.cc src/loss.h src/matrix.h src/real.h
+loss.o: src/loss.cc src/loss.h src/matrix.h src/real.h src/utils.h src/model.h src/vector.h
 	$(CXX) $(CXXFLAGS) -c src/loss.cc
 
-productquantizer.o: src/productquantizer.cc src/productquantizer.h src/utils.h
+productquantizer.o: src/productquantizer.cc src/productquantizer.h src/real.h src/vector.h
 	$(CXX) $(CXXFLAGS) -c src/productquantizer.cc
 
-densematrix.o: src/densematrix.cc src/densematrix.h src/utils.h src/matrix.h
+densematrix.o: src/densematrix.cc src/densematrix.h src/utils.h src/matrix.h src/real.h src/vector.h
 	$(CXX) $(CXXFLAGS) -c src/densematrix.cc
 
-quantmatrix.o: src/quantmatrix.cc src/quantmatrix.h src/utils.h src/matrix.h
+quantmatrix.o: src/quantmatrix.cc src/quantmatrix.h src/matrix.h src/densematrix.h src/productquantizer.h src/real.h src/vector.h
 	$(CXX) $(CXXFLAGS) -c src/quantmatrix.cc
 
-vector.o: src/vector.cc src/vector.h src/utils.h
+vector.o: src/vector.cc src/vector.h src/matrix.h src/real.h
 	$(CXX) $(CXXFLAGS) -c src/vector.cc
 
-model.o: src/model.cc src/model.h src/args.h
+model.o: src/model.cc src/model.h src/utils.h src/matrix.h src/utils.h src/loss.h src/real.h src/vector.h
 	$(CXX) $(CXXFLAGS) -c src/model.cc
 
-utils.o: src/utils.cc src/utils.h
+utils.o: src/utils.cc src/utils.h src/real.h
 	$(CXX) $(CXXFLAGS) -c src/utils.cc
 
-meter.o: src/meter.cc src/meter.h
+meter.o: src/meter.cc src/meter.h src/dictionary.h src/utils.h src/real.h src/args.h
 	$(CXX) $(CXXFLAGS) -c src/meter.cc
 
 fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc
 
-fasttext: $(OBJS) src/fasttext.cc
+fasttext: $(OBJS) src/main.cc
 	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext
 
 clean:


### PR DESCRIPTION
Hi, 

we have fixed the dependence issues in the Makefile. It has around 10 missing deps and 5 redundant deps. The dep info should be correct after this correction. 

This  is a follow-up PR to https://github.com/facebookresearch/fastText/pull/831

Thanks
Vemake. 