### PR TITLE
Fix ValueError when predictions is an empty list

### DIFF
--- a/python/fasttext_module/fasttext/FastText.py
+++ b/python/fasttext_module/fasttext/FastText.py
@@ -154,7 +154,11 @@ class _FastText(object):
         else:
             text = check(text)
             predictions = self.f.predict(text, k, threshold, on_unicode_error)
-            probs, labels = zip(*predictions)
+            if len(predictions) != 0:
+                probs, labels = zip(*predictions)
+            else:
+                probs = tuple()
+                labels = tuple()
 
             return labels, np.array(probs, copy=False)
 


### PR DESCRIPTION
https://github.com/facebookresearch/fastText/blob/40a77442a756ab160ae3465b26322f6e480405d9/python/fasttext_module/fasttext/FastText.py#L156

Depending on the threshold parameter, the `predictions` variable can be an empty list. The empty list will cause `ValueError: need more than 0 values to unpack` when trying to `zip`.

This pull-request fixes this bug.