### PR TITLE
Added ability to compare two words directly

### DIFF
--- a/python/fasttext_module/fasttext/pybind/fasttext_pybind.cc
+++ b/python/fasttext_module/fasttext/pybind/fasttext_pybind.cc
@@ -402,6 +402,11 @@ PYBIND11_MODULE(fasttext_pybind, m) {
             return m.getNN(word, k);
           })
       .def(
+          "getSimilarity",
+          [](fasttext::FastText& m, const std::string& word1, const std::string& word2) {
+            return m.getSimilarity(word1, word2);
+          })
+      .def(
           "getAnalogies",
           [](fasttext::FastText& m,
              const std::string& wordA,

--- a/src/densematrix.cc
+++ b/src/densematrix.cc
@@ -112,6 +112,18 @@ real DenseMatrix::dotRow(const Vector& vec, int64_t i) const {
   return d;
 }
 
+real DenseMatrix::dotTwoVecs(const Vector& vec1, const Vector& vec2) const {
+  assert(vec1.size() == n_);
+  real d = 0.0;
+  for (int64_t j = 0; j < n_; j++) {
+    d += vec1[j] * vec2[j];
+  }
+  if (std::isnan(d)) {
+    throw EncounteredNaNError();
+  }
+  return d;
+}
+
 void DenseMatrix::addVectorToRow(const Vector& vec, int64_t i, real a) {
   assert(i >= 0);
   assert(i < m_);

--- a/src/densematrix.h
+++ b/src/densematrix.h
@@ -67,6 +67,7 @@ class DenseMatrix : public Matrix {
   void l2NormRow(Vector& norms) const;
 
   real dotRow(const Vector&, int64_t) const override;
+  real dotTwoVecs(const Vector&, const Vector&) const;
   void addVectorToRow(const Vector&, int64_t, real) override;
   void addRowToVector(Vector& x, int32_t i) const override;
   void addRowToVector(Vector& x, int32_t i, real a) const override;

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -527,6 +527,39 @@ void FastText::lazyComputeWordVectors() {
   }
 }
 
+real FastText::getSimilarity(
+    const std::string& word1,
+    const std::string& word2) {
+  Vector queryWord1(args_->dim);
+  Vector queryWord2(args_->dim);
+
+  getWordVector(queryWord1, word1);
+  getWordVector(queryWord2, word2);
+
+  lazyComputeWordVectors();
+  assert(wordVectors_);
+
+  return getSimilarity(*wordVectors_, queryWord1, queryWord2);
+}
+
+real FastText::getSimilarity(const DenseMatrix& wordVectors,
+  const Vector& queryWord1,
+  const Vector& queryWord2) {
+
+  real word1Norm = queryWord1.norm();
+  real word2Norm = queryWord2.norm();
+
+  real queryNorm = std::sqrt(word1Norm * word1Norm * word2Norm * word2Norm);
+  if (std::abs(queryNorm) < 1e-8) {
+    queryNorm = 1;
+  }
+
+  real dp = wordVectors.dotTwoVecs(queryWord1, queryWord2);
+  real similarity = dp / queryNorm;
+
+  return similarity;
+}
+
 std::vector<std::pair<real, std::string>> FastText::getNN(
     const std::string& word,
     int32_t k) {

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -55,6 +55,10 @@ class FastText {
       const Vector& queryVec,
       int32_t k,
       const std::set<std::string>& banSet);
+  real getSimilarity(
+      const DenseMatrix& wordVectors,
+      const Vector& queryVec1,
+      const Vector& queryVec2);
   void lazyComputeWordVectors();
   void printInfo(real, real, std::ostream&);
   std::shared_ptr<Matrix> getInputMatrixFromFile(const std::string&) const;
@@ -134,6 +138,10 @@ class FastText {
   std::vector<std::pair<real, std::string>> getNN(
       const std::string& word,
       int32_t k);
+
+  real getSimilarity(
+      const std::string& word1,
+      const std::string& word2);
 
   std::vector<std::pair<real, std::string>> getAnalogies(
       int32_t k,


### PR DESCRIPTION
I added the ability to find the similarity between two given words to the underlying C++ code. This function can be called as model.f.getSimilarity("word1", "word2") from python where "model" is a FastText object.