### PR TITLE
Fix env path in interpreter for some bash scripts

### DIFF
--- a/alignment/example.sh
+++ b/alignment/example.sh
@@ -1,4 +1,4 @@
-#!/bin/usr/env sh
+#!/usr/bin/env sh
 # Copyright (c) 2018-present, Facebook, Inc.
 # All rights reserved.
 #

--- a/crawl/download_crawl.sh
+++ b/crawl/download_crawl.sh
@@ -1,4 +1,4 @@
-#!/bin/usr/env sh
+#!/usr/bin/env sh
 # Copyright (c) 2018-present, Facebook, Inc.
 # All rights reserved.
 #

--- a/crawl/filter_dedup.sh
+++ b/crawl/filter_dedup.sh
@@ -1,4 +1,4 @@
-#!/bin/usr/env sh
+#!/usr/bin/env sh
 # Copyright (c) 2018-present, Facebook, Inc.
 # All rights reserved.
 #

--- a/crawl/process_wet_file.sh
+++ b/crawl/process_wet_file.sh
@@ -1,4 +1,4 @@
-#!/bin/usr/env sh
+#!/usr/bin/env sh
 # Copyright (c) 2018-present, Facebook, Inc.
 # All rights reserved.
 #


### PR DESCRIPTION
Some bash scripts have `#!/bin/usr/env` instead of `#!/bin/usr/env` as interpreter, this fixes it. 