### PR TITLE
Add a python __version__ variable

### DIFF
--- a/python/fasttext_module/fasttext/__init__.py
+++ b/python/fasttext_module/fasttext/__init__.py
@@ -20,3 +20,5 @@ from .FastText import EOW
 from .FastText import cbow
 from .FastText import skipgram
 from .FastText import supervised
+
+from .version import __version__

--- a/python/fasttext_module/fasttext/version.py
+++ b/python/fasttext_module/fasttext/version.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+__version__ = '0.9.1'

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,12 @@ import os
 import subprocess
 import platform
 import io
+import imp
 
-__version__ = '0.9.1'
+__version__ = imp.load_source(
+    'fasttext.version',
+    os.path.join(os.path.dirname(__file__), 'python', 'fasttext_module', 'fasttext', 'version.py')
+).__version__
 FASTTEXT_SRC = "src"
 
 # Based on https://github.com/pybind/python_example


### PR DESCRIPTION
This PR adds a `__version__` variable to python package.
We became able to get the fastText python package version as follows.

```py
import fasttext

faxttext.__version__
>>> 0.9.1
```

I use `imp` package in `setup.py` for reading version information from `version.py`.
However, `imp` is deprecated now.
When fastText end support Python 2, We can use `importlib.machinery.SourceFileLoader` instead of `imp`.

Best regards.