### PR TITLE
predict() extended - arranges class labels and scores in a single array 

### DIFF
--- a/python/fasttext_module/fasttext/FastText.py
+++ b/python/fasttext_module/fasttext/FastText.py
@@ -121,7 +121,9 @@ class _FastText(object):
         self.f.getInputVector(b, ind)
         return np.array(b)
 
-    def predict(self, text, k=1, threshold=0.0, on_unicode_error='strict'):
+    def predict(self, text, k=1, threshold=0.0, on_unicode_error='strict',
+                transpose_axis=False):
+
         """
         Given a string, get a list of labels and a list of
         corresponding probabilities. k controls the number
@@ -131,7 +133,8 @@ class _FastText(object):
         the returned labels by a threshold on probability. A
         choice of 0.5 will return labels with at least 0.5
         probability. k and threshold will be applied together to
-        determine the returned labels.
+        determine the returned labels. transpose_axis arranges
+        class labels and scores in a single array.
 
         This function assumes to be given
         a single line of text. We split words on whitespace (space,
@@ -152,12 +155,20 @@ class _FastText(object):
             entry += "\n"
             return entry
 
+        def transpose(labels, probs):
+            """Arrange class labels and probs in a single array"""
+            return [ (labels[i], probs[i]) for i in range(len(labels)) ]
+
+
         if type(text) == list:
             text = [check(entry) for entry in text]
             all_labels, all_probs = self.f.multilinePredict(
                 text, k, threshold, on_unicode_error)
 
-            return all_labels, all_probs
+            if transpose_axis:
+                return transpose(all_labels, all_probs)
+            else:
+                return all_labels, all_probs
         else:
             text = check(text)
             predictions = self.f.predict(text, k, threshold, on_unicode_error)

--- a/python/fasttext_module/fasttext/tests/test_script.py
+++ b/python/fasttext_module/fasttext/tests/test_script.py
@@ -452,6 +452,33 @@ class TestFastTextUnitPy(unittest.TestCase):
             gotError = True
         self.assertTrue(gotError)
 
+    def gen_test_predict_transpose(self, kwargs):
+        def check_single_sentence(pred, pred_t):
+            self.assertEqual(pred[0], pred_t[0])
+            self.assertTrue(np.array_equal(pred[1], pred_t[1]))
+            self.assertEqual(len(pred[0]), len(pred_t[0]))
+
+        def check_multi_sentence(pred, pred_t):
+            labels_all = []
+            probs_all = []
+            for pair in pred_t:
+                labels_all.append(pair[0])
+                probs_all.append(pair[1])
+            self.assertEqual(pred[0], labels_all)
+            self.assertTrue(np.array_equal(pred[1], probs_all))
+            self.assertEqual(len(pred_t), len(pred[0]))
+
+        f = build_supervised_model(get_random_data(100), kwargs)
+        text = [" ".join(get_random_words(20)) for i in range(3)]
+        # check list of sentences
+        pred = f.predict(text, k=5)
+        pred_t = f.predict(text, k=5, transpose_axis=True)
+        check_multi_sentence(pred, pred_t)
+        # check single sentence
+        pred = f.predict(text[0], k=2)
+        pred_t = f.predict(text[0], k=2, transpose_axis=True)
+        check_single_sentence(pred, pred_t)
+
 
 # Generate a supervised test case
 # The returned function will be set as an attribute to a test class


### PR DESCRIPTION
Summary:
Issue #946: predict(..., transpose_axis=True) arranges class labels and scores in a single array with one 2-tuple per input data point.
example:
[
    (['A', 'B'], [0.76, 0.46])
    (['G', 'C'], [0.95, 0.13])
]