### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -100,6 +100,10 @@ const siteConfig = {
   scripts: [
     '/tabber.js',
   ],
+  algolia: {
+    apiKey: 'e0bc41aeaf88d333a51aa07f5dd05757',
+    indexName: 'fasttext',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.