### PR TITLE
Add build dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
-.*.swp
+*.swp
+*.swo
 *.o
+*.a
+*.dSYM
+*.so
+*.dylib
+*.pyc
 *.bin
 *.vec
+
 data
 fasttext
 result
+build/
+build_*/


### PR DESCRIPTION
add build/, build_*/, and some binary files to the gitignore that you wouldn't want in your git repo

Signed-off-by: David Pollack <david@da3.net>