### PR TITLE
Fix compilation on PowerPC (#1018)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@
 #
 
 CXX = c++
-CXXFLAGS = -pthread -std=c++11 -march=native
+TARGET_MACHINE ?= $(shell uname -m)
+CXXFLAGS = -pthread -std=c++11
+ifneq (,$(findstring ppc64,$(TARGET_MACHINE)))
+	CXXFLAGS += -mcpu=native -mtune=native
+else
+	CXXFLAGS += -march=native
+endif
 OBJS = args.o autotune.o matrix.o dictionary.o loss.o productquantizer.o densematrix.o quantmatrix.o vector.o model.o utils.o meter.o fasttext.o
 INCLUDES = -I.
 


### PR DESCRIPTION
`-march=native` option not supported on powerpc systems

On PowerPC we can use `-mcpu=native -mtune=native` instead

Here are a few relevant links:

https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
https://gcc.gnu.org/onlinedocs/gcc/RS_002f6000-and-PowerPC-Options.html#RS_002f6000-and-PowerPC-Options

ref issue #1018

all test passed on my PowerPC machine