### PR TITLE
Add example for replacing shuf command for systems without it.

### DIFF
--- a/tests/shuf
+++ b/tests/shuf
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $RANDOM

--- a/tests/shuf.README
+++ b/tests/shuf.README
@@ -1,0 +1,8 @@
+# You may be missing shuf command
+
+These options seem to work.
+
+create a file named shuf with the following and make it executable.
+echo $RANDOM
+
+There is a sample shuf file that you can make executable.


### PR DESCRIPTION
Simple example for replacing shuf tool to help with mac install of fasttext test data.  