### PR TITLE
-DNDEBUG added to default cmake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (fasttext_VERSION_MINOR 1)
 
 include_directories(fasttext)
 
-set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
+set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native -DNDEBUG")
 
 set(HEADER_FILES
     src/args.h


### PR DESCRIPTION
Default cmake build flags are preset for performance optimized build, however a NDEBUG define is not set. If the NDEBUG is not set then asserts are not optimized out and runtime performance is degraded.