### PR TITLE
Fix test_supervised_util_test for python3

### DIFF
--- a/python/fasttext_module/fasttext/tests/test_script.py
+++ b/python/fasttext_module/fasttext/tests/test_script.py
@@ -206,7 +206,7 @@ class TestFastTextUnitPy(unittest.TestCase):
                 model = train_supervised(input=tmpf.name, **kwargs)
                 true_labels = []
                 all_words = []
-                with open(tmpf2.name, 'r') as fid:
+                with open(tmpf2.name, 'r', encoding="UTF-8") as fid:
                     for line in fid:
                         if sys.version_info < (3, 0):
                             line = line.decode("UTF-8")


### PR DESCRIPTION
Fixes errors like this testing in python3:

```
======================================================================
ERROR: test_supervised_util_test_0 (fasttext.tests.test_script.TestFastTextUnitPy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/work/003c13a04323e5dc26c2c02cd9c8df29e6c6/google3/runfiles/google3/third_party/py/fasttext/tests/test_script.py", line 590, in test
    "gen_" + test_name)(self, copy.deepcopy(kwargs))
  File "/build/work/003c13a04323e5dc26c2c02cd9c8df29e6c6/google3/runfiles/google3/third_party/py/fasttext/tests/test_script.py", line 229, in gen_test_supervised_util_test
    check(get_random_data(100, min_words_line=2))
  File "/build/work/003c13a04323e5dc26c2c02cd9c8df29e6c6/google3/runfiles/google3/third_party/py/fasttext/tests/test_script.py", line 210, in check
    for line in fid:
  File "<embedded stdlib>/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc7 in position 9: ordinal not in range(128)
```