### PR TITLE
Fix build wasm in latest emsdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ clean:
 
 
 EMCXX = em++
-EMCXXFLAGS = --bind --std=c++11 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['addOnPostRun', 'FS']" -s "DISABLE_EXCEPTION_CATCHING=0" -s "EXCEPTION_DEBUG=1" -s "FORCE_FILESYSTEM=1" -s "MODULARIZE=1" -s "EXPORT_ES6=1" -s 'EXPORT_NAME="FastTextModule"' -Isrc/
+EMCXXFLAGS = --bind --std=c++11 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s "EXPORTED_RUNTIME_METHODS=['addOnPostRun', 'FS']" -s "DISABLE_EXCEPTION_CATCHING=0" -s "EXCEPTION_DEBUG=1" -s "FORCE_FILESYSTEM=1" -s "MODULARIZE=1" -s "EXPORT_ES6=1" -s 'EXPORT_NAME="FastTextModule"' -Isrc/ -r
 EMOBJS = args.bc autotune.bc matrix.bc dictionary.bc loss.bc productquantizer.bc densematrix.bc quantmatrix.bc vector.bc model.bc utils.bc meter.bc fasttext.bc main.bc
 
 


### PR DESCRIPTION
# Overview
Fix: https://github.com/facebookresearch/fastText/issues/1166

# Execution
In local OSX.
```
$ docker pull emscripten/emsdk
$ docker run -it emscripten/emsdk bash
```

In Container.
```
$ em++ --version
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 2.0.30 (f782b50a7f8dded7cd0e2c7ee4fed41ab743f5c0)
Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
This is free and open source software under the MIT license.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

# --- checkout this PR ---
$ git clone https://github.com/vaaaaanquish/fastText.git
$ git checkout patch-build-wasm
$ make wasm
...
$ ls webassembly/
README.md  doc  fasttext.js  fasttext_wasm.cc  fasttext_wasm.js  fasttext_wasm.wasm
```