### PR TITLE
Exclude MSVC-incompatible command-line flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ set (fasttext_VERSION_MINOR 1)
 
 include_directories(fasttext)
 
-set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
+if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
+endif()
 
 set(HEADER_FILES
     src/args.h


### PR DESCRIPTION
While building with `cl.exe` seems to work, building with `clang-cl.exe` fails without this patch.