### PR TITLE
Fixed msvc compiler error:  error C2065: 'ssize_t': undeclared identi…

### DIFF
--- a/python/fasttext_module/fasttext/pybind/fasttext_pybind.cc
+++ b/python/fasttext_module/fasttext/pybind/fasttext_pybind.cc
@@ -20,6 +20,11 @@
 #include <sstream>
 #include <stdexcept>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 using namespace pybind11::literals;
 namespace py = pybind11;
 


### PR DESCRIPTION
Hi,

I've fixed compiler error with `pip install` on Windows OS.

Maybe this is not the right spot, but never the less: feel free to change.