### PR TITLE
Add pyproject.toml to comply with PEP-518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "pybind11"]


### PR DESCRIPTION
Adds pyproject.toml to comply with PEP-518, which fixes the building of the library by poetry - See https://github.com/python-poetry/poetry/issues/6113 . This is a copy of https://github.com/facebookresearch/fastText/pull/1270 , but I have signed the CLA.

