### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Due to this error trying to install the fasttext package  on Python 3.10 Running setup.py install for fasttext did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      C:\Program Files\Python310\lib\site-packages\setuptools\dist.py:697: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead