### PR TITLE
Add pyproject.toml to comply with PEP-518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "pybind11"]


### PR DESCRIPTION
`fastText` is a dependency for a package called `EasyNMT` and the lack of PEP-518 support means that poetry installation is not possible for `EasyNMT`.

This commit should add compatibility and by forcing poetry to search here (by making `fastText` an explicit github dependency) we can move forward with using `EasyNMT`.