### PR TITLE
fix compile error with gcc13 #1281

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -9,6 +9,7 @@
 #include "args.h"
 
 #include <stdlib.h>
+#include <cstdint>
 
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
Due to[ header dependency changes](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes) in GCC 13, we need to include the <cstdint> header.