### PR TITLE
fix missing dependency of dictionary.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ autotune.o: src/autotune.cc src/autotune.h
 matrix.o: src/matrix.cc src/matrix.h
 	$(CXX) $(CXXFLAGS) -c src/matrix.cc
 
-dictionary.o: src/dictionary.cc src/dictionary.h src/args.h
+dictionary.o: src/dictionary.cc src/dictionary.h src/args.h src/real.h
 	$(CXX) $(CXXFLAGS) -c src/dictionary.cc
 
 loss.o: src/loss.cc src/loss.h src/matrix.h src/real.h


### PR DESCRIPTION
Hi，
We have detected the following dependency errors in your public project. 
The target dictionary.o miss dependency src/real.h. If we modify src/real.h, the dictionary.o will not be rebuilt. We just tried to fix this error.

All errors can be find in 
[dep_error_b733943_clean.csv](https://github.com/facebookresearch/fastText/files/14206893/dep_error_b733943_clean.csv)