### PR TITLE
Declare a build dependency on `pip`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11"]
+requires = ["pip", "setuptools", "wheel", "pybind11"]


### PR DESCRIPTION
Currently installing `fasttext` with [`uv`](https://github.com/astral-sh/uv) fails, as `fasttext`'s setup.py file tries to use `pip` to install `pybind11` if it is not already installed. `uv` does not, by default, include `pip` in new virtual environments:

```zsh
% uv venv new-venv                 
Using Python 3.12.2 interpreter at: /Users/alexw/.pyenv/versions/3.12.2/bin/python3
Creating virtualenv at: new-venv
Activate with: source new-venv/bin/activate
% source new-venv/bin/activate     
(new-venv) % uv pip install fasttext
error: Failed to download and build: fasttext==0.9.2
  Caused by: Failed to build: fasttext==0.9.2
  Caused by: Build backend failed to determine extra requires with `build_wheel()`:
--- stdout:

--- stderr:
/Users/alexw/Library/Caches/uv/.tmp2ZDKtZ/.venv/bin/python: No module named pip
Traceback (most recent call last):
  File "<string>", line 38, in __init__
ModuleNotFoundError: No module named 'pybind11'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/Users/alexw/Library/Caches/uv/.tmp2ZDKtZ/.venv/lib/python3.12/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexw/Library/Caches/uv/.tmp2ZDKtZ/.venv/lib/python3.12/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
    self.run_setup()
  File "/Users/alexw/Library/Caches/uv/.tmp2ZDKtZ/.venv/lib/python3.12/site-packages/setuptools/build_meta.py", line 487, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/Users/alexw/Library/Caches/uv/.tmp2ZDKtZ/.venv/lib/python3.12/site-packages/setuptools/build_meta.py", line 311, in run_setup
    exec(code, locals())
  File "<string>", line 72, in <module>
  File "<string>", line 41, in __init__
RuntimeError: pybind11 install failed.
---
```

This PR makes `fasttext` installable with `uv` by adding `pip` as a build dependency.